### PR TITLE
Yun example: change one Serial -> Console

### DIFF
--- a/examples/mqtt_yun/mqtt_yun.ino
+++ b/examples/mqtt_yun/mqtt_yun.ino
@@ -95,7 +95,7 @@ void loop() {
 
   // ping the server to keep the mqtt connection alive
   if(! mqtt.ping()) {
-    Serial.println(F("MQTT Ping failed."));
+    Console.println(F("MQTT Ping failed."));
   }
 
   delay(1000);


### PR DESCRIPTION
I may be mistaken, but I think all of the printing is to `Console`, and maybe in preparing this example, one call to `Serial` was missed.