### PR TITLE
dtostrf for other SAMD boards

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -21,7 +21,7 @@
 // SOFTWARE.
 #include "Adafruit_MQTT.h"
 
-#ifdef ARDUINO_SAMD_ZERO
+#ifndef dtostrf
 static char *dtostrf (double val, signed char width, unsigned char prec, char *sout) {
   char fmt[20];
   sprintf(fmt, "%%%d.%df", width, prec);


### PR DESCRIPTION
Changed preprocessor directive to create the dtostrf function whenever
it is not defined in order to support more SAMD boards (including
MKR1000) without adding more board defines to the ifdef.