### PR TITLE
Master

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -21,7 +21,7 @@
 // SOFTWARE.
 #include "Adafruit_MQTT.h"
 
-#ifndef dtostrf
+#if defined(ARDUINO_SAMD_ZERO) || defined(ARDUINO_SAMD_MKR1000)
 static char *dtostrf (double val, signed char width, unsigned char prec, char *sout) {
   char fmt[20];
   sprintf(fmt, "%%%d.%df", width, prec);

--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -21,7 +21,7 @@
 // SOFTWARE.
 #include "Adafruit_MQTT.h"
 
-#ifdef ARDUINO_SAMD_ZERO
+#ifndef dtostrf
 static char *dtostrf (double val, signed char width, unsigned char prec, char *sout) {
   char fmt[20];
   sprintf(fmt, "%%%d.%df", width, prec);


### PR DESCRIPTION
Adding the MKR1000 board to the list of boards for which the dtostrf
function should be defined (for lack of a better way to determine
if the function is available elsewhere).