### PR TITLE
Remove MQTT instance from Adafruit_MQTT_Subscribe

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -794,16 +794,16 @@ uint8_t Adafruit_MQTT::disconnectPacket(uint8_t *packet) {
 // Adafruit_MQTT_Publish Definition ////////////////////////////////////////////
 
 Adafruit_MQTT_Publish::Adafruit_MQTT_Publish(Adafruit_MQTT *mqttserver,
-                                             const char *feed, uint8_t q) {
+                                             const char *t, uint8_t q) {
   mqtt = mqttserver;
-  topic = feed;
+  topic = t;
   qos = q;
 }
 
 Adafruit_MQTT_Publish::Adafruit_MQTT_Publish(Adafruit_MQTT *mqttserver,
-                                             const __FlashStringHelper *feed, uint8_t q) {
+                                             const __FlashStringHelper *t, uint8_t q) {
   mqtt = mqttserver;
-  topic = (const char *)feed;
+  topic = (const char *)t;
   qos = q;
 }
 
@@ -838,10 +838,8 @@ bool Adafruit_MQTT_Publish::publish(uint8_t *payload, uint16_t bLen) {
 
 // Adafruit_MQTT_Subscribe Definition //////////////////////////////////////////
 
-Adafruit_MQTT_Subscribe::Adafruit_MQTT_Subscribe(Adafruit_MQTT *mqttserver,
-                                                 const char *feed, uint8_t q) {
-  mqtt = mqttserver;
-  topic = feed;
+Adafruit_MQTT_Subscribe::Adafruit_MQTT_Subscribe(const char *t, uint8_t q) {
+  topic = t;
   qos = q;
   datalen = 0;
   callback_uint32t = 0;
@@ -849,10 +847,8 @@ Adafruit_MQTT_Subscribe::Adafruit_MQTT_Subscribe(Adafruit_MQTT *mqttserver,
   callback_double = 0;
 }
 
-Adafruit_MQTT_Subscribe::Adafruit_MQTT_Subscribe(Adafruit_MQTT *mqttserver,
-                                                 const __FlashStringHelper *feed, uint8_t q) {
-  mqtt = mqttserver;
-  topic = (const char *)feed;
+Adafruit_MQTT_Subscribe::Adafruit_MQTT_Subscribe(const __FlashStringHelper *t, uint8_t q) {
+  topic = (const char *)t;
   qos = q;
   datalen = 0;
   callback_uint32t = 0;

--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -257,8 +257,8 @@ class Adafruit_MQTT {
 
 class Adafruit_MQTT_Publish {
  public:
-  Adafruit_MQTT_Publish(Adafruit_MQTT *mqttserver, const char *feed, uint8_t qos = 0);
-  Adafruit_MQTT_Publish(Adafruit_MQTT *mqttserver, const __FlashStringHelper *feed, uint8_t qos = 0);
+  Adafruit_MQTT_Publish(Adafruit_MQTT *mqttserver, const char *t, uint8_t qos = 0);
+  Adafruit_MQTT_Publish(Adafruit_MQTT *mqttserver, const __FlashStringHelper *t, uint8_t qos = 0);
 
   bool publish(const char *s);
   bool publish(double f, uint8_t precision=2);  // Precision controls the minimum number of digits after decimal.
@@ -276,8 +276,8 @@ private:
 
 class Adafruit_MQTT_Subscribe {
  public:
-  Adafruit_MQTT_Subscribe(Adafruit_MQTT *mqttserver, const char *feedname, uint8_t q=0);
-  Adafruit_MQTT_Subscribe(Adafruit_MQTT *mqttserver, const __FlashStringHelper *feedname, uint8_t q=0);
+  Adafruit_MQTT_Subscribe(const char *t, uint8_t q=0);
+  Adafruit_MQTT_Subscribe(const __FlashStringHelper *t, uint8_t q=0);
 
   void setCallback(SubscribeCallbackUInt32Type callb);
   void setCallback(SubscribeCallbackDoubleType callb);
@@ -296,8 +296,6 @@ class Adafruit_MQTT_Subscribe {
   SubscribeCallbackDoubleType callback_double;
   SubscribeCallbackBufferType callback_buffer;
 
- private:
-  Adafruit_MQTT *mqtt;
 };
 
 

--- a/examples/adafruitio_errors_esp8266/adafruitio_errors_esp8266.ino
+++ b/examples/adafruitio_errors_esp8266/adafruitio_errors_esp8266.ino
@@ -57,7 +57,7 @@ Adafruit_MQTT_Publish photocell = Adafruit_MQTT_Publish(&mqtt, PHOTOCELL_FEED);
 
 // Setup a feed called 'onoff' for subscribing to changes.
 const char ONOFF_FEED[] PROGMEM = AIO_USERNAME "/feeds/onoff";
-Adafruit_MQTT_Subscribe onoffbutton = Adafruit_MQTT_Subscribe(&mqtt, ONOFF_FEED);
+Adafruit_MQTT_Subscribe onoffbutton = Adafruit_MQTT_Subscribe(ONOFF_FEED);
 
 /*************************** Error Reporting *********************************/
 

--- a/examples/mqtt_2subs_esp8266/mqtt_2subs_esp8266.ino
+++ b/examples/mqtt_2subs_esp8266/mqtt_2subs_esp8266.ino
@@ -57,9 +57,9 @@ Adafruit_MQTT_Client mqtt(&client, MQTT_SERVER, AIO_SERVERPORT, MQTT_USERNAME, M
 // Notice MQTT paths for AIO follow the form: <username>/feeds/<feedname>
 // Setup a feed called 'onoff' for subscribing to changes.
 const char ONOFF_FEED[] PROGMEM = AIO_USERNAME "/feeds/onoff";
-Adafruit_MQTT_Subscribe onoffbutton = Adafruit_MQTT_Subscribe(&mqtt, ONOFF_FEED);
+Adafruit_MQTT_Subscribe onoffbutton = Adafruit_MQTT_Subscribe(ONOFF_FEED);
 const char SLIDER_FEED[] PROGMEM = AIO_USERNAME "/feeds/slider";
-Adafruit_MQTT_Subscribe slider = Adafruit_MQTT_Subscribe(&mqtt, SLIDER_FEED);
+Adafruit_MQTT_Subscribe slider = Adafruit_MQTT_Subscribe(SLIDER_FEED);
 
 /*************************** Sketch Code ************************************/
 

--- a/examples/mqtt_cc3k/mqtt_cc3k.ino
+++ b/examples/mqtt_cc3k/mqtt_cc3k.ino
@@ -70,7 +70,7 @@ Adafruit_MQTT_Publish photocell = Adafruit_MQTT_Publish(&mqtt, PHOTOCELL_FEED);
 
 // Setup a feed called 'onoff' for subscribing to changes.
 const char ONOFF_FEED[] PROGMEM = AIO_USERNAME "/feeds/onoff";
-Adafruit_MQTT_Subscribe onoffbutton = Adafruit_MQTT_Subscribe(&mqtt, ONOFF_FEED);
+Adafruit_MQTT_Subscribe onoffbutton = Adafruit_MQTT_Subscribe(ONOFF_FEED);
 
 /*************************** Sketch Code ************************************/
 

--- a/examples/mqtt_esp8266/mqtt_esp8266.ino
+++ b/examples/mqtt_esp8266/mqtt_esp8266.ino
@@ -56,7 +56,7 @@ Adafruit_MQTT_Publish photocell = Adafruit_MQTT_Publish(&mqtt, PHOTOCELL_FEED);
 
 // Setup a feed called 'onoff' for subscribing to changes.
 const char ONOFF_FEED[] PROGMEM = AIO_USERNAME "/feeds/onoff";
-Adafruit_MQTT_Subscribe onoffbutton = Adafruit_MQTT_Subscribe(&mqtt, ONOFF_FEED);
+Adafruit_MQTT_Subscribe onoffbutton = Adafruit_MQTT_Subscribe(ONOFF_FEED);
 
 /*************************** Sketch Code ************************************/
 

--- a/examples/mqtt_esp8266_callback/mqtt_esp8266_callback.ino
+++ b/examples/mqtt_esp8266_callback/mqtt_esp8266_callback.ino
@@ -41,13 +41,13 @@ Adafruit_MQTT_Client mqtt(&client, AIO_SERVER, AIO_SERVERPORT, AIO_USERNAME, AIO
 /****************************** Feeds ***************************************/
 
 // Setup a feed called 'time' for subscribing to current time
-Adafruit_MQTT_Subscribe timefeed = Adafruit_MQTT_Subscribe(&mqtt, "time/seconds");
+Adafruit_MQTT_Subscribe timefeed = Adafruit_MQTT_Subscribe("time/seconds");
 
 // Setup a feed called 'slider' for subscribing to changes on the slider
-Adafruit_MQTT_Subscribe slider = Adafruit_MQTT_Subscribe(&mqtt, AIO_USERNAME "/feeds/slider", MQTT_QOS_1);
+Adafruit_MQTT_Subscribe slider = Adafruit_MQTT_Subscribe(AIO_USERNAME "/feeds/slider", MQTT_QOS_1);
 
 // Setup a feed called 'onoff' for subscribing to changes to the button
-Adafruit_MQTT_Subscribe onoffbutton = Adafruit_MQTT_Subscribe(&mqtt, AIO_USERNAME "/feeds/onoff", MQTT_QOS_1);
+Adafruit_MQTT_Subscribe onoffbutton = Adafruit_MQTT_Subscribe(AIO_USERNAME "/feeds/onoff", MQTT_QOS_1);
 
 /*************************** Sketch Code ************************************/
 

--- a/examples/mqtt_ethernet/mqtt_ethernet.ino
+++ b/examples/mqtt_ethernet/mqtt_ethernet.ino
@@ -66,7 +66,7 @@ Adafruit_MQTT_Publish photocell = Adafruit_MQTT_Publish(&mqtt, PHOTOCELL_FEED);
 
 // Setup a feed called 'onoff' for subscribing to changes.
 const char ONOFF_FEED[] PROGMEM = AIO_USERNAME "/feeds/onoff";
-Adafruit_MQTT_Subscribe onoffbutton = Adafruit_MQTT_Subscribe(&mqtt, ONOFF_FEED);
+Adafruit_MQTT_Subscribe onoffbutton = Adafruit_MQTT_Subscribe(ONOFF_FEED);
 
 /*************************** Sketch Code ************************************/
 

--- a/examples/mqtt_fona/mqtt_fona.ino
+++ b/examples/mqtt_fona/mqtt_fona.ino
@@ -77,7 +77,7 @@ Adafruit_MQTT_Publish photocell = Adafruit_MQTT_Publish(&mqtt, PHOTOCELL_FEED);
 
 // Setup a feed called 'onoff' for subscribing to changes.
 const char ONOFF_FEED[] PROGMEM = AIO_USERNAME "/feeds/onoff";
-Adafruit_MQTT_Subscribe onoffbutton = Adafruit_MQTT_Subscribe(&mqtt, ONOFF_FEED);
+Adafruit_MQTT_Subscribe onoffbutton = Adafruit_MQTT_Subscribe(ONOFF_FEED);
 
 /*************************** Sketch Code ************************************/
 

--- a/examples/mqtt_winc1500/mqtt_winc1500.ino
+++ b/examples/mqtt_winc1500/mqtt_winc1500.ino
@@ -63,7 +63,7 @@ Adafruit_MQTT_Publish photocell = Adafruit_MQTT_Publish(&mqtt, PHOTOCELL_FEED);
 
 // Setup a feed called 'onoff' for subscribing to changes.
 const char ONOFF_FEED[] PROGMEM = AIO_USERNAME "/feeds/onoff";
-Adafruit_MQTT_Subscribe onoffbutton = Adafruit_MQTT_Subscribe(&mqtt, ONOFF_FEED);
+Adafruit_MQTT_Subscribe onoffbutton = Adafruit_MQTT_Subscribe(ONOFF_FEED);
 
 /*************************** Sketch Code ************************************/
 

--- a/examples/mqtt_yun/mqtt_yun.ino
+++ b/examples/mqtt_yun/mqtt_yun.ino
@@ -53,7 +53,7 @@ Adafruit_MQTT_Publish photocell = Adafruit_MQTT_Publish(&mqtt, PHOTOCELL_FEED);
 
 // Setup a feed called 'onoff' for subscribing to changes.
 const char ONOFF_FEED[] PROGMEM = AIO_USERNAME "/feeds/onoff";
-Adafruit_MQTT_Subscribe onoffbutton = Adafruit_MQTT_Subscribe(&mqtt, ONOFF_FEED);
+Adafruit_MQTT_Subscribe onoffbutton = Adafruit_MQTT_Subscribe(ONOFF_FEED);
 
 /*************************** Sketch Code ************************************/
 


### PR DESCRIPTION
The MQTT instance doesn't seem to need the MQTT server instance, so this pull req removes it and changes all of the examples to match the new simplified constructor args.

This branch also renames IO specific `feed` arguments to `t` in the Adafruit_MQTT_Subscribe and Adafruit_MQTT_Publish constructors.