### PR TITLE
Add Support for Adafruit IO Arduino

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -472,10 +472,15 @@ void Adafruit_MQTT::processPackets(int16_t timeout) {
 	//Serial.print("*** calling double callback with : "); Serial.println(data);
 	sub->callback_double(data);
       }
-      else if (sub->callback_buffer != NULL) {
+      else if (sub->callback_buffer != null) {
 	// huh lets do the callback in buffer mode
-	//Serial.print("*** calling buffer callback with : "); Serial.println(data);
+	//serial.print("*** calling buffer callback with : "); serial.println(data);
 	sub->callback_buffer((char *)sub->lastread, sub->datalen);
+      }
+      else if (sub->callback_io != null) {
+        // huh lets do the callback in io mode
+        //serial.print("*** calling io instance callback with : "); serial.println(data);
+        sub->callback_io((char *)sub->lastread, sub->datalen);
       }
     }
 
@@ -861,6 +866,7 @@ Adafruit_MQTT_Subscribe::Adafruit_MQTT_Subscribe(Adafruit_MQTT *mqttserver,
   callback_uint32t = 0;
   callback_buffer = 0;
   callback_double = 0;
+  callback_io = 0;
 }
 
 Adafruit_MQTT_Subscribe::Adafruit_MQTT_Subscribe(Adafruit_MQTT *mqttserver,
@@ -871,7 +877,7 @@ Adafruit_MQTT_Subscribe::Adafruit_MQTT_Subscribe(Adafruit_MQTT *mqttserver,
   datalen = 0;
   callback_uint32t = 0;
   callback_buffer = 0;
-  callback_double = 0;
+  callback_io = 0;
 }
 
 void Adafruit_MQTT_Subscribe::setCallback(SubscribeCallbackUInt32Type cb) {
@@ -886,8 +892,13 @@ void Adafruit_MQTT_Subscribe::setCallback(SubscribeCallbackBufferType cb) {
   callback_buffer = cb;
 }
 
+void Adafruit_MQTT_Subscribe::setCallback(SubscribeCallbackIOType cb) {
+  callback_io = cb;
+}
+
 void Adafruit_MQTT_Subscribe::removeCallback(void) {
   callback_uint32t = 0;
   callback_buffer = 0;
   callback_double = 0;
+  callback_io = 0;
 }

--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -480,7 +480,7 @@ void Adafruit_MQTT::processPackets(int16_t timeout) {
       else if (sub->callback_io != NULL) {
         // huh lets do the callback in io mode
         //serial.print("*** calling io instance callback with : "); serial.println(data);
-        sub->*callback_io((char *)sub->lastread, sub->datalen);
+        ((sub->io_feed)->*(sub->callback_io))((char *)sub->lastread, sub->datalen);
       }
     }
 
@@ -867,6 +867,7 @@ Adafruit_MQTT_Subscribe::Adafruit_MQTT_Subscribe(Adafruit_MQTT *mqttserver,
   callback_buffer = 0;
   callback_double = 0;
   callback_io = 0;
+  io_feed = 0;
 }
 
 Adafruit_MQTT_Subscribe::Adafruit_MQTT_Subscribe(Adafruit_MQTT *mqttserver,
@@ -878,6 +879,7 @@ Adafruit_MQTT_Subscribe::Adafruit_MQTT_Subscribe(Adafruit_MQTT *mqttserver,
   callback_uint32t = 0;
   callback_buffer = 0;
   callback_io = 0;
+  io_feed = 0;
 }
 
 void Adafruit_MQTT_Subscribe::setCallback(SubscribeCallbackUInt32Type cb) {
@@ -892,8 +894,9 @@ void Adafruit_MQTT_Subscribe::setCallback(SubscribeCallbackBufferType cb) {
   callback_buffer = cb;
 }
 
-void Adafruit_MQTT_Subscribe::setCallback(SubscribeCallbackIOType cb) {
+void Adafruit_MQTT_Subscribe::setCallback(AdafruitIO_Feed *f, SubscribeCallbackIOType cb) {
   callback_io = cb;
+  io_feed = f;
 }
 
 void Adafruit_MQTT_Subscribe::removeCallback(void) {
@@ -901,4 +904,5 @@ void Adafruit_MQTT_Subscribe::removeCallback(void) {
   callback_buffer = 0;
   callback_double = 0;
   callback_io = 0;
+  io_feed = 0;
 }

--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -232,6 +232,20 @@ int8_t Adafruit_MQTT::connect() {
   return 0;
 }
 
+int8_t Adafruit_MQTT::connect(const char *user, const char *pass)
+{
+  username = user;
+  password = pass;
+  return connect();
+}
+
+int8_t Adafruit_MQTT::connect(const __FlashStringHelper *user, const __FlashStringHelper *pass)
+{
+  username = (const char*)user;
+  password = (const char*)pass;
+  return connect();
+}
+
 uint16_t Adafruit_MQTT::processPacketsUntil(uint8_t *buffer, uint8_t waitforpackettype, uint16_t timeout) {
   uint16_t len;
   while (len = readFullPacket(buffer, MAXBUFFERSIZE, timeout)) {

--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -472,15 +472,15 @@ void Adafruit_MQTT::processPackets(int16_t timeout) {
 	//Serial.print("*** calling double callback with : "); Serial.println(data);
 	sub->callback_double(data);
       }
-      else if (sub->callback_buffer != null) {
+      else if (sub->callback_buffer != NULL) {
 	// huh lets do the callback in buffer mode
 	//serial.print("*** calling buffer callback with : "); serial.println(data);
 	sub->callback_buffer((char *)sub->lastread, sub->datalen);
       }
-      else if (sub->callback_io != null) {
+      else if (sub->callback_io != NULL) {
         // huh lets do the callback in io mode
         //serial.print("*** calling io instance callback with : "); serial.println(data);
-        sub->callback_io((char *)sub->lastread, sub->datalen);
+        sub->*callback_io((char *)sub->lastread, sub->datalen);
       }
     }
 

--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -133,8 +133,8 @@ class Adafruit_MQTT {
                 const __FlashStringHelper *pass);
   Adafruit_MQTT(const char *server,
                 uint16_t port,
-                const char *user,
-                const char *pass);
+                const char *user = "",
+                const char *pass = "");
   Adafruit_MQTT(const __FlashStringHelper *server,
                 uint16_t port,
                 const __FlashStringHelper *user,
@@ -153,6 +153,8 @@ class Adafruit_MQTT {
   // Use connectErrorString() to get a printable string version of the
   // error.
   int8_t connect();
+  int8_t connect(const char *user, const char *pass);
+  int8_t connect(const __FlashStringHelper *user, const __FlashStringHelper *pass);
 
   // Return a printable string version of the error code returned by
   // connect(). This returns a __FlashStringHelper*, which points to a

--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -288,7 +288,7 @@ class Adafruit_MQTT_Subscribe {
   void setCallback(SubscribeCallbackUInt32Type callb);
   void setCallback(SubscribeCallbackDoubleType callb);
   void setCallback(SubscribeCallbackBufferType callb);
-  void setCallback(SubscribeCallbackIOType callb);
+  void setCallback(AdafruitIO_Feed *io, SubscribeCallbackIOType callb);
   void removeCallback(void);
 
   const char *topic;
@@ -303,6 +303,8 @@ class Adafruit_MQTT_Subscribe {
   SubscribeCallbackDoubleType callback_double;
   SubscribeCallbackBufferType callback_buffer;
   SubscribeCallbackIOType     callback_io;
+
+  AdafruitIO_Feed *io_feed;
 
  private:
   Adafruit_MQTT *mqtt;

--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -29,6 +29,10 @@
 #define strncasecmp_P(f1, f2, len) strncasecmp((f1), (f2), (len))
 #endif
 
+#define ADAFRUIT_MQTT_VERSION_MAJOR 0
+#define ADAFRUIT_MQTT_VERSION_MINOR 15
+#define ADAFRUIT_MQTT_VERSION_PATCH 0
+
 // Uncomment/comment to turn on/off debug output messages.
 //#define MQTT_DEBUG
 // Uncomment/comment to turn on/off error output messages.

--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -108,12 +108,16 @@
 // eg max-subscription-payload-size
 #define SUBSCRIPTIONDATALEN 20
 
+class AdafruitIO_Feed;  // forward decl
+
 //Function pointer that returns an int
 typedef void (*SubscribeCallbackUInt32Type)(uint32_t);
 // returns a double
 typedef void (*SubscribeCallbackDoubleType)(double);
 // returns a chunk of raw data
 typedef void (*SubscribeCallbackBufferType)(char *str, uint16_t len);
+// returns an io data wrapper instance
+typedef void (AdafruitIO_Feed::*SubscribeCallbackIOType)(char *str, uint16_t len);
 
 extern void printBuffer(uint8_t *buffer, uint16_t len);
 
@@ -284,6 +288,7 @@ class Adafruit_MQTT_Subscribe {
   void setCallback(SubscribeCallbackUInt32Type callb);
   void setCallback(SubscribeCallbackDoubleType callb);
   void setCallback(SubscribeCallbackBufferType callb);
+  void setCallback(SubscribeCallbackIOType callb);
   void removeCallback(void);
 
   const char *topic;
@@ -297,6 +302,7 @@ class Adafruit_MQTT_Subscribe {
   SubscribeCallbackUInt32Type callback_uint32t;
   SubscribeCallbackDoubleType callback_double;
   SubscribeCallbackBufferType callback_buffer;
+  SubscribeCallbackIOType     callback_io;
 
  private:
   Adafruit_MQTT *mqtt;

--- a/Adafruit_MQTT_CC3000.h
+++ b/Adafruit_MQTT_CC3000.h
@@ -44,7 +44,7 @@ class Adafruit_MQTT_CC3000 : public Adafruit_MQTT {
   {}
 
   Adafruit_MQTT_CC3000(Adafruit_CC3000 *cc3k, const char *server, uint16_t port,
-                       const char *user, const char *pass):
+                       const char *user = "", const char *pass = ""):
     Adafruit_MQTT(server, port, user, pass),
     cc3000(cc3k)
   {}

--- a/Adafruit_MQTT_Client.h
+++ b/Adafruit_MQTT_Client.h
@@ -42,7 +42,7 @@ class Adafruit_MQTT_Client : public Adafruit_MQTT {
   {}
 
   Adafruit_MQTT_Client(Client *client, const char *server, uint16_t port,
-                       const char *user, const char *pass):
+                       const char *user="", const char *pass=""):
     Adafruit_MQTT(server, port, user, pass),
     client(client)
   {}

--- a/Adafruit_MQTT_FONA.h
+++ b/Adafruit_MQTT_FONA.h
@@ -42,7 +42,7 @@ class Adafruit_MQTT_FONA : public Adafruit_MQTT {
   {}
 
   Adafruit_MQTT_FONA(Adafruit_FONA *f, const char *server, uint16_t port,
-                     const char *user, const char *pass):
+                     const char *user="", const char *pass=""):
     Adafruit_MQTT(server, port, user, pass),
     fona(f)
   {}

--- a/examples/adafruitio_anon_time_esp8266/adafruitio_anon_time_esp8266.ino
+++ b/examples/adafruitio_anon_time_esp8266/adafruitio_anon_time_esp8266.ino
@@ -1,0 +1,122 @@
+/***************************************************
+  Adafruit MQTT Library ESP8266 Adafruit IO Anonymous Time Query
+
+  Must use the latest version of ESP8266 Arduino from:
+    https://github.com/esp8266/Arduino
+
+  Works great with Adafruit's Huzzah ESP board & Feather
+  ----> https://www.adafruit.com/product/2471
+  ----> https://www.adafruit.com/products/2821
+
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
+  products from Adafruit!
+
+  Written by Adafruit Industries.
+  MIT license, all text above must be included in any redistribution
+ ****************************************************/
+#include <ESP8266WiFi.h>
+#include "Adafruit_MQTT.h"
+#include "Adafruit_MQTT_Client.h"
+
+/************************* WiFi Access Point *********************************/
+#define WLAN_SSID       "network"
+#define WLAN_PASS       "password"
+
+/************************* Adafruit.io Setup *********************************/
+#define AIO_SERVER      "io.adafruit.com"
+#define AIO_SERVERPORT  8883
+
+WiFiClientSecure client;
+Adafruit_MQTT_Client mqtt(&client, AIO_SERVER, AIO_SERVERPORT);
+
+Adafruit_MQTT_Subscribe timefeed = Adafruit_MQTT_Subscribe(&mqtt, "time/seconds");
+
+// set timezone offset from UTC
+int timeZone = -4; // UTC - 4 eastern daylight time (nyc)
+int interval = 4; // trigger every X hours
+
+int last_min = -1;
+
+void timecallback(uint32_t current) {
+  // adjust to local time zone
+  current += (timeZone * 60 * 60);
+  int curr_hour = (current / 60 / 60) % 24;
+  int curr_min  = (current / 60 ) % 60;
+  int curr_sec  = (current) % 60;
+
+  Serial.print("Time: "); 
+  Serial.print(curr_hour); Serial.print(':'); 
+  Serial.print(curr_min); Serial.print(':'); 
+  Serial.println(curr_sec);
+  
+  // only trigger on minute change
+  if(curr_min != last_min) {
+    last_min = curr_min;
+    
+    Serial.println("This will print out every minute!");
+  }
+}
+
+void setup() {
+
+  Serial.begin(115200);
+  delay(10);
+
+  Serial.print(F("\nAdafruit IO anonymous Time Demo"));
+
+  WiFi.begin(WLAN_SSID, WLAN_PASS);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(F("."));
+  }
+  Serial.println(F(" WiFi connected."));
+
+  timefeed.setCallback(timecallback);
+  mqtt.subscribe(&timefeed);
+
+}
+
+void loop() {
+
+  // Ensure the connection to the MQTT server is alive (this will make the first
+  // connection and automatically reconnect when disconnected).  See the MQTT_connect
+  // function definition further below.
+  MQTT_connect();
+
+  // wait 10 seconds for subscription messages
+  // since we have no other tasks in this example.
+  mqtt.processPackets(10000);
+
+  // keep the connection alive
+  mqtt.ping();
+
+}
+
+// Function to connect and reconnect as necessary to the MQTT server.
+// Should be called in the loop function and it will take care if connecting.
+void MQTT_connect() {
+  int8_t ret;
+
+  // Stop if already connected.
+  if (mqtt.connected()) {
+    return;
+  }
+
+  Serial.print("Connecting to MQTT... ");
+
+  uint8_t retries = 3;
+  while ((ret = mqtt.connect()) != 0) { // connect will return 0 for connected
+       Serial.println(mqtt.connectErrorString(ret));
+       Serial.println("Retrying MQTT connection in 5 seconds...");
+       mqtt.disconnect();
+       delay(5000);  // wait 5 seconds
+       retries--;
+       if (retries == 0) {
+         // basically die and wait for WDT to reset me
+         while (1);
+       }
+  }
+
+  Serial.println("MQTT Connected!");
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MQTT Library
-version=0.14.2
+version=0.15.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=MQTT library that supports the CC3000, FONA, ESP8266, Yun, and generic Arduino Client hardware.


### PR DESCRIPTION
* adds the ability to connect to MQTT brokers without a username or password
* you can now set username & pass outside of the constructor via `connect()`
* adds support for adafruit_io_arduino callbacks