### PR TITLE
Added support for retain on publish

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -293,13 +293,13 @@ bool Adafruit_MQTT::disconnect() {
 }
 
 
-bool Adafruit_MQTT::publish(const char *topic, const char *data, uint8_t qos) {
-    return publish(topic, (uint8_t*)(data), strlen(data), qos);
+bool Adafruit_MQTT::publish(const char *topic, const char *data, uint8_t qos, uint8_t retain) {
+    return publish(topic, (uint8_t*)(data), strlen(data), qos, retain);
 }
 
-bool Adafruit_MQTT::publish(const char *topic, uint8_t *data, uint16_t bLen, uint8_t qos) {
+bool Adafruit_MQTT::publish(const char *topic, uint8_t *data, uint16_t bLen, uint8_t qos, uint8_t retain) {
   // Construct and send publish packet.
-  uint16_t len = publishPacket(buffer, topic, data, bLen, qos);
+  uint16_t len = publishPacket(buffer, topic, data, bLen, qos, retain);
   if (!sendPacket(buffer, len))
     return false;
 
@@ -634,7 +634,7 @@ uint8_t Adafruit_MQTT::connectPacket(uint8_t *packet) {
 
 // as per http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718040
 uint16_t Adafruit_MQTT::publishPacket(uint8_t *packet, const char *topic,
-                                     uint8_t *data, uint16_t bLen, uint8_t qos) {
+                                     uint8_t *data, uint16_t bLen, uint8_t qos, uint8_t retain) {
   uint8_t *p = packet;
   uint16_t len=0;
 
@@ -647,7 +647,7 @@ uint16_t Adafruit_MQTT::publishPacket(uint8_t *packet, const char *topic,
   len += bLen; // payload length
 
   // Now you can start generating the packet!
-  p[0] = MQTT_CTRL_PUBLISH << 4 | qos << 1;
+  p[0] = MQTT_CTRL_PUBLISH << 4 | qos << 1 | retain << 0;
   p++;
 
   // fill in packet[1] last
@@ -770,37 +770,38 @@ uint8_t Adafruit_MQTT::disconnectPacket(uint8_t *packet) {
 // Adafruit_MQTT_Publish Definition ////////////////////////////////////////////
 
 Adafruit_MQTT_Publish::Adafruit_MQTT_Publish(Adafruit_MQTT *mqttserver,
-                                             const char *feed, uint8_t q) {
+                                             const char *feed, uint8_t q, uint8_t r) {
   mqtt = mqttserver;
   topic = feed;
   qos = q;
+  retain = r;
 }
 bool Adafruit_MQTT_Publish::publish(int32_t i) {
   char payload[12];
   ltoa(i, payload, 10);
-  return mqtt->publish(topic, payload, qos);
+  return mqtt->publish(topic, payload, qos, retain);
 }
 
 bool Adafruit_MQTT_Publish::publish(uint32_t i) {
   char payload[11];
   ultoa(i, payload, 10);
-  return mqtt->publish(topic, payload, qos);
+  return mqtt->publish(topic, payload, qos, retain);
 }
 
 bool Adafruit_MQTT_Publish::publish(double f, uint8_t precision) {
   char payload[41];  // Need to technically hold float max, 39 digits and minus sign.
   dtostrf(f, 0, precision, payload);
-  return mqtt->publish(topic, payload, qos);
+  return mqtt->publish(topic, payload, qos, retain);
 }
 
 bool Adafruit_MQTT_Publish::publish(const char *payload) {
-  return mqtt->publish(topic, payload, qos);
+  return mqtt->publish(topic, payload, qos, retain);
 }
 
 //publish buffer of arbitrary length
 bool Adafruit_MQTT_Publish::publish(uint8_t *payload, uint16_t bLen) {
 
-  return mqtt->publish(topic, payload, bLen, qos);
+  return mqtt->publish(topic, payload, bLen, qos, retain);
 }
 
 

--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -174,8 +174,8 @@ class Adafruit_MQTT {
 
   // Publish a message to a topic using the specified QoS level.  Returns true
   // if the message was published, false otherwise.
-  bool publish(const char *topic, const char *payload, uint8_t qos = 0);
-  bool publish(const char *topic, uint8_t *payload, uint16_t bLen, uint8_t qos = 0);
+  bool publish(const char *topic, const char *payload, uint8_t qos = 0, uint8_t retain = 0);
+  bool publish(const char *topic, uint8_t *payload, uint16_t bLen, uint8_t qos = 0, uint8_t retain = 0);
 
   // Add a subscription to receive messages for a topic.  Returns true if the
   // subscription could be added or was already present, false otherwise.
@@ -240,7 +240,7 @@ class Adafruit_MQTT {
   // Functions to generate MQTT packets.
   uint8_t connectPacket(uint8_t *packet);
   uint8_t disconnectPacket(uint8_t *packet);
-  uint16_t publishPacket(uint8_t *packet, const char *topic, uint8_t *payload, uint16_t bLen, uint8_t qos);
+  uint16_t publishPacket(uint8_t *packet, const char *topic, uint8_t *payload, uint16_t bLen, uint8_t qos, uint8_t retain);
   uint8_t subscribePacket(uint8_t *packet, const char *topic, uint8_t qos);
   uint8_t unsubscribePacket(uint8_t *packet, const char *topic);
   uint8_t pingPacket(uint8_t *packet);
@@ -250,7 +250,7 @@ class Adafruit_MQTT {
 
 class Adafruit_MQTT_Publish {
  public:
-  Adafruit_MQTT_Publish(Adafruit_MQTT *mqttserver, const char *feed, uint8_t qos = 0);
+  Adafruit_MQTT_Publish(Adafruit_MQTT *mqttserver, const char *feed, uint8_t qos = 0, uint8_t retain = 0);
 
   bool publish(const char *s);
   bool publish(double f, uint8_t precision=2);  // Precision controls the minimum number of digits after decimal.
@@ -264,6 +264,7 @@ private:
   Adafruit_MQTT *mqtt;
   const char *topic;
   uint8_t qos;
+  uint8_t retain;
 };
 
 class Adafruit_MQTT_Subscribe {


### PR DESCRIPTION
Added an optional flag on publish to set the retain flag. If set to true the MQTT broker will retain the last published data. As the flag is optional it will not break any existing code and the default is not to retain as before.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.

