### PR TITLE
Prevent publishing "NaN" literally

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -788,6 +788,8 @@ bool Adafruit_MQTT_Publish::publish(uint32_t i) {
 }
 
 bool Adafruit_MQTT_Publish::publish(double f, uint8_t precision) {
+  if (isnan(f))
+    return false;
   char payload[41];  // Need to technically hold float max, 39 digits and minus sign.
   dtostrf(f, 0, precision, payload);
   return mqtt->publish(topic, payload, qos);


### PR DESCRIPTION
- **Describe the scope of your change** - Prevent publishing (return false) if passing a NaN float/double

- **Describe any known limitations with your change.** - You won't be able to see literal NaNs from MQTT feeds (but you should be tracing math/logic issues through your code/prototype, not through MQTT feeds and dashboards)

- **Please run any tests or examples that can exercise your modified code.** - WFM (compiles fine as a library to existing code)