### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -3,7 +3,7 @@ Adafruit_MQTT_CC3000	KEYWORD1
 Adafruit_MQTT_FONA	KEYWORD1
 Adafruit_MQTT_Client	KEYWORD1
 Adafruit_MQTT_Publish	KEYWORD1
-Adafruit_MQTT_Subscribe KEYWORD1
+Adafruit_MQTT_Subscribe	KEYWORD1
 connect	KEYWORD2
 connectErrorString	KEYWORD2
 disconnect	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords