### PR TITLE
Support MQTT retain flag on publishing.

### DIFF
--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -178,8 +178,8 @@ class Adafruit_MQTT {
 
   // Publish a message to a topic using the specified QoS level.  Returns true
   // if the message was published, false otherwise.
-  bool publish(const char *topic, const char *payload, uint8_t qos = 0);
-  bool publish(const char *topic, uint8_t *payload, uint16_t bLen, uint8_t qos = 0);
+  bool publish(const char *topic, const char *payload, uint8_t qos = 0, bool retain = false);
+  bool publish(const char *topic, uint8_t *payload, uint16_t bLen, uint8_t qos = 0, bool retain = false);
 
   // Add a subscription to receive messages for a topic.  Returns true if the
   // subscription could be added or was already present, false otherwise.
@@ -244,7 +244,7 @@ class Adafruit_MQTT {
   // Functions to generate MQTT packets.
   uint8_t connectPacket(uint8_t *packet);
   uint8_t disconnectPacket(uint8_t *packet);
-  uint16_t publishPacket(uint8_t *packet, const char *topic, uint8_t *payload, uint16_t bLen, uint8_t qos);
+  uint16_t publishPacket(uint8_t *packet, const char *topic, uint8_t *payload, uint16_t bLen, uint8_t qos, uint8_t retain);
   uint8_t subscribePacket(uint8_t *packet, const char *topic, uint8_t qos);
   uint8_t unsubscribePacket(uint8_t *packet, const char *topic);
   uint8_t pingPacket(uint8_t *packet);
@@ -254,7 +254,7 @@ class Adafruit_MQTT {
 
 class Adafruit_MQTT_Publish {
  public:
-  Adafruit_MQTT_Publish(Adafruit_MQTT *mqttserver, const char *feed, uint8_t qos = 0);
+  Adafruit_MQTT_Publish(Adafruit_MQTT *mqttserver, const char *feed, uint8_t qos = 0, bool retain = false);
 
   bool publish(const char *s);
   bool publish(double f, uint8_t precision=2);  // Precision controls the minimum number of digits after decimal.
@@ -268,6 +268,7 @@ private:
   Adafruit_MQTT *mqtt;
   const char *topic;
   uint8_t qos;
+  bool retain;
 };
 
 class Adafruit_MQTT_Subscribe {


### PR DESCRIPTION
This resolves issue #20 by allowing the user to specify the retain flag
on the publisher object. This flag is useful for slow publishers so that
a new subscription will immediately receive the last published message.

This change adds a new boolean parameter to the Adafruit_MQTT_Publish constructor to set the retention flag for this publisher instance. To preserve existing compatibility the parameter is defaulted to false. This flag is then propagated to the implementing function Adafruit_MQTT::publishPacket where it is combined into the MQTT_CTRL_PUBLISH flags as a single bit flag.

This has then been confirmed using a Mosquitto MQTT broker to check that resulting messages were
 being retained and presented promptly to new subscribers.
