### PR TITLE
Fix min() usage when using STL C++

### DIFF
--- a/Adafruit_MQTT_Client.cpp
+++ b/Adafruit_MQTT_Client.cpp
@@ -81,7 +81,7 @@ bool Adafruit_MQTT_Client::sendPacket(uint8_t *buffer, uint16_t len) {
     if (client->connected()) {
       // send 250 bytes at most at a time, can adjust this later based on Client
 
-      uint16_t sendlen = min(len, 250);
+      uint16_t sendlen = min(len, (uint16_t)250);
       //Serial.print("Sending: "); Serial.println(sendlen);
       ret = client->write(buffer, sendlen);
       DEBUG_PRINT(F("Client sendPacket returned: ")); DEBUG_PRINTLN(ret);


### PR DESCRIPTION
Using the https://github.com/stm32duino/Arduino_Core_STM32 with Adafruit_MQTT_Library, there is a build issue.
```
.../libraries/Adafruit_MQTT_Library/Adafruit_MQTT_Client.cpp: In member function 'virtual bool Adafruit_MQTT_Client::sendPacket(uint8_t*, uint16_t)':
.../libraries/Adafruit_MQTT_Library/Adafruit_MQTT_Client.cpp:84:38: error: no matching function for call to 'min(uint16_t&, int)'
       uint16_t sendlen = min(len, 250);
                                      ^
...
.../packages/STM32/tools/arm-none-eabi-gcc/6-2017-q2-update/arm-none-eabi/include/c++/6.3.1/bits/stl_algo.h:3453:5: note: candidate: template<class _Tp, class _Compare> _Tp std::min(std::initializer_list<_Tp>, _Compare)
     min(initializer_list<_Tp> __l, _Compare __comp)
```
This patch allows to use min function of the standard C++ library without break compatibility with the min() macro if STL C++ is not used.

