### PR TITLE
Allowing for larger MQTT messages

### DIFF
--- a/Adafruit_MQTT_Client.cpp
+++ b/Adafruit_MQTT_Client.cpp
@@ -76,16 +76,20 @@ uint16_t Adafruit_MQTT_Client::readPacket(uint8_t *buffer, uint16_t maxlen,
 
 bool Adafruit_MQTT_Client::sendPacket(uint8_t *buffer, uint16_t len) {
   uint16_t ret = 0;
-
+  uint16_t bufferOffset = 0;
+  //Serial.print("Buffer recieved : "); DebugPrinter::println(len);
   while (len > 0) {
     if (client->connected()) {
       // send 250 bytes at most at a time, can adjust this later based on Client
 
-      uint16_t sendlen = min(len, 250);
-      //Serial.print("Sending: "); Serial.println(sendlen);
-      ret = client->write(buffer, sendlen);
+       uint16_t sendlen = min(len, MAX_SINGLE_PACKET_SIZE);
+
+      ret = client->write(buffer + bufferOffset, sendlen);
+	  client->flush();
+	  //DebugPrinter::println("Sent");
       DEBUG_PRINT(F("Client sendPacket returned: ")); DEBUG_PRINTLN(ret);
       len -= ret;
+	  bufferOffset += ret;
 
       if (ret != sendlen) {
 	DEBUG_PRINTLN("Failed to send packet.");

--- a/Adafruit_MQTT_Client.cpp
+++ b/Adafruit_MQTT_Client.cpp
@@ -77,7 +77,7 @@ uint16_t Adafruit_MQTT_Client::readPacket(uint8_t *buffer, uint16_t maxlen,
 bool Adafruit_MQTT_Client::sendPacket(uint8_t *buffer, uint16_t len) {
   uint16_t ret = 0;
   uint16_t bufferOffset = 0;
-  //Serial.print("Buffer recieved : "); DebugPrinter::println(len);
+  //Serial.print("Buffer recieved : ");
   while (len > 0) {
     if (client->connected()) {
       // send 250 bytes at most at a time, can adjust this later based on Client
@@ -86,7 +86,6 @@ bool Adafruit_MQTT_Client::sendPacket(uint8_t *buffer, uint16_t len) {
 
       ret = client->write(buffer + bufferOffset, sendlen);
 	  client->flush();
-	  //DebugPrinter::println("Sent");
       DEBUG_PRINT(F("Client sendPacket returned: ")); DEBUG_PRINTLN(ret);
       len -= ret;
 	  bufferOffset += ret;

--- a/Adafruit_MQTT_Client.h
+++ b/Adafruit_MQTT_Client.h
@@ -28,6 +28,7 @@
 
 // How long to delay waiting for new data to be available in readPacket.
 #define MQTT_CLIENT_READINTERVAL_MS 10
+#define MAX_SINGLE_PACKET_SIZE 1200
 
 
 // MQTT client implementation for a generic Arduino Client interface.  Can work


### PR DESCRIPTION
I found a limitation in regards to writing MQTT messages larger than 250 could be resolved by writing to the TCP socket repeatedly so long as the packet written is below the sockets buffer size, which is 1400 bytes on a WINC1500.  