### PR TITLE
Support large packet publishing with ESP8266

### DIFF
--- a/Adafruit_MQTT_Client.cpp
+++ b/Adafruit_MQTT_Client.cpp
@@ -79,9 +79,14 @@ bool Adafruit_MQTT_Client::sendPacket(uint8_t *buffer, uint16_t len) {
 
   while (len > 0) {
     if (client->connected()) {
+		
       // send 250 bytes at most at a time, can adjust this later based on Client
+#ifdef ESP8266
+		uint16_t sendlen = len; //ESP8266's implementation can handle large packets by itself.
+#else
+		uint16_t sendlen = len > 250 ? 250 : len;
+#endif
 
-      uint16_t sendlen = len > 250 ? 250 : len;
       //Serial.print("Sending: "); Serial.println(sendlen);
       ret = client->write(buffer, sendlen);
       DEBUG_PRINT(F("Client sendPacket returned: ")); DEBUG_PRINTLN(ret);


### PR DESCRIPTION
When sending large packets with ESP8266's WiFiClient, the library prints a couple hundred bytes and then garbage. The Adafruit library sends 250 bytes at a time to publish the packet. This is where it fails. Fortunately, ESP8266's implementation of Client supports large packets by itself. It will take care of splitting data even beyond the IP packet's MTU.

This fix conditionally enables sending the complete package to WiFiClient with a simple IFDEF ESP8266.

Tested on Arduino 1.8.5.