### PR TITLE
Packet zero length protection

### DIFF
--- a/Adafruit_MQTT_Client.cpp
+++ b/Adafruit_MQTT_Client.cpp
@@ -53,6 +53,7 @@ uint16_t Adafruit_MQTT_Client::readPacket(uint8_t *buffer, uint16_t maxlen,
   uint16_t len = 0;
   int16_t t = timeout;
 
+  if (maxlen == 0) return 0;
   while (client->connected() && (timeout >= 0)) {
     //DEBUG_PRINT('.');
     while (client->available()) {


### PR DESCRIPTION
Client hangs when server returns zero-length packet. Pull request simply adds protective if.