### PR TITLE
Add fingerprint to verifyFingerprint()

### DIFF
--- a/examples/adafruitio_secure_esp8266/adafruitio_secure_esp8266.ino
+++ b/examples/adafruitio_secure_esp8266/adafruitio_secure_esp8266.ino
@@ -114,6 +114,7 @@ void loop() {
 void verifyFingerprint() {
 
   const char* host = AIO_SERVER;
+  const char* fingerprint = AIO_SSL_FINGERPRINT;
 
   Serial.print("Connecting to ");
   Serial.println(host);


### PR DESCRIPTION
Fix Compiler Error: 
126: error: 'fingerprint' was not declared in this scope
   if (client.verify(fingerprint, host)) {
                     ^
exit status 1

- Scope of Change: add variable to function to fix compiler error;
-  No known limitations
