### PR TITLE
Auto-negotiate MQTT version, rather than using a #define.

### DIFF
--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -63,9 +63,6 @@
   #define ERROR_PRINTBUFFER(buffer, len) {}
 #endif
 
-// Use 3 (MQTT 3.0) or 4 (MQTT 3.1.1)
-#define MQTT_PROTOCOL_LEVEL 4
-
 #define MQTT_CTRL_CONNECT     0x1
 #define MQTT_CTRL_CONNECTACK  0x2
 #define MQTT_CTRL_PUBLISH     0x3
@@ -235,6 +232,7 @@ class Adafruit_MQTT {
   uint8_t will_retain;
   uint8_t buffer[MAXBUFFERSIZE];  // one buffer, used for all incoming/outgoing
   uint16_t packet_id_counter;
+  uint8_t mqtt_protocol_level;
 
  private:
   Adafruit_MQTT_Subscribe *subscriptions[MAXSUBSCRIPTIONS];


### PR DESCRIPTION
A few changes in Adafruit_MQTT.h and .cpp that allow connecting to any MQTT broker without knowing in advance what protocol version it uses. 

The original used a hard-coded
`#define MQTT_PROTOCOL_LEVEL`
of either 3 or 4 to distinguish between the two protocol versions. In this version, mqtt_protocol_level is a member variable, and the protocol version is determined in the same (kludgy) way that Paho does it -- try to connect with it set to 4, then switch to 3 if that fails. 

But this should be transparent to the calling code, aside from taking a tiny bit longer.