### PR TITLE
Update Adafruit_MQTT.h

### DIFF
--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -113,7 +113,7 @@
 #if defined  (__AVR_ATmega32U4__) || defined(__AVR_ATmega328P__)
   #define SUBSCRIPTIONDATALEN 20
 #else
-  #define SUBSCRIPTIONDATALEN 100
+  #define SUBSCRIPTIONDATALEN 450
 #endif
 
 class AdafruitIO_MQTT;   // forward decl

--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -95,7 +95,7 @@
 // Largest full packet we're able to send.
 // Need to be able to store at least ~90 chars for a connect packet with full
 // 23 char client ID.
-#define MAXBUFFERSIZE (150)
+#define MAXBUFFERSIZE (500)
 
 #define MQTT_CONN_USERNAMEFLAG    0x80
 #define MQTT_CONN_PASSWORDFLAG    0x40


### PR DESCRIPTION
Extend the MAXBUFFERSIZE for large message payloads.

- **Description** 
Sometimes messages with large payloads must be sent/received to/from the cloud.
E.g. many device attributes must be changed in the cloud, a list with available
devices must be received. In such cases if another informations are added to 
the payload too, the maximal buffer size of 150 bytes is too small. 
The message is truncated and can not be processed correctly.
The problem occurred with us with the ESP8266 device.

Googling, I've seen that other users had this problem earlier with too small 
MAXBUFFERSIZE of 150 bytes.

- **Limitations**
I have not seen any limitations on increasing the MAXBUFFERSIZE to 500 bytes.

- **Examples code**  
I have increased MAXBUFFERSIZE to 500 (bytes). With new size we can send longer messages.
The function for checking the maximal possible message size is:

/**
 * Check if the message to the cloud exceeds the maximum possible size.
 *
 * @param updateMsg Essential part of the message.
 * @param threshold Threshold for the composite message (137/487).
 */
bool CotSmartRestProcessor::checkUpdateMsgLength(String updateMsg, int threshold) {

    int mqttPubLen = updateMsg.length();

    // Get device name length:
    mqttPubLen += _persistence.get().getCotUser().length();

    // Get templates name length:
    mqttPubLen += xID.length();

    // threshold (137) is empirical maximal sum of MQTT strings,
    // if  #define MAXBUFFERSIZE (150)  is defined in Adafruit_MQTT.h
    // If MAXBUFFERSIZE is greater than 150, this threshold may be corresponding greater.
    if (mqttPubLen > threshold) {
    	DT_DEBUG_PRINTLN_ERROR("### MQTT PUB length %d greater than threshold %d, possible buffer overflow !", mqttPubLen, threshold);
    	DT_DEBUG_PRINTLN_ERROR("### Please reduce the length of string parameters for updateDevice() !");
    	return false;
    }

    return true;
}
