### PR TITLE
Fix compile-bug - "'fingerprint' is not defined"

### DIFF
--- a/examples/adafruitio_secure_esp8266/adafruitio_secure_esp8266.ino
+++ b/examples/adafruitio_secure_esp8266/adafruitio_secure_esp8266.ino
@@ -42,7 +42,7 @@ Adafruit_MQTT_Client mqtt(&client, AIO_SERVER, AIO_SERVERPORT, AIO_USERNAME, AIO
 
 // io.adafruit.com SHA1 fingerprint. Current fingerprint can be verified via: 
 //   echo | openssl s_client -connect io.adafruit.com:443 |& openssl x509 -fingerprint -noout
-#define AIO_SSL_FINGERPRINT "77 00 54 2D DA E7 D8 03 27 31 23 99 EB 27 DB CB A5 4C 57 18"
+const char* fingerprint = "77 00 54 2D DA E7 D8 03 27 31 23 99 EB 27 DB CB A5 4C 57 18"
 
 /****************************** Feeds ***************************************/
 


### PR DESCRIPTION
The MQTTS-example won't compile, this fixes that.