### PR TITLE
Allow connection to brokers with no authentication

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -552,6 +552,7 @@ bool Adafruit_MQTT::ping(uint8_t num) {
 // small differences in the protocol):
 //   http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#connect
 uint8_t Adafruit_MQTT::connectPacket(uint8_t *packet) {
+  String nullString = "";
   uint8_t *p = packet;
   uint16_t len;
 
@@ -589,10 +590,12 @@ uint8_t Adafruit_MQTT::connectPacket(uint8_t *packet) {
 
   }
 
-  if (pgm_read_byte(username) != 0)
+  if (!(nullString.equals(username)) && pgm_read_byte(username) != 0){
     p[0] |= MQTT_CONN_USERNAMEFLAG;
-  if (pgm_read_byte(password) != 0)
+  }
+  if (!(nullString.equals(password)) && pgm_read_byte(password) != 0){
     p[0] |= MQTT_CONN_PASSWORDFLAG;
+  }
   p++;
 
   p[0] = MQTT_CONN_KEEPALIVE >> 8;
@@ -619,10 +622,10 @@ uint8_t Adafruit_MQTT::connectPacket(uint8_t *packet) {
     p = stringprint(p, will_payload);
   }
 
-  if (pgm_read_byte(username) != 0) {
+  if (!(nullString.equals(username)) && pgm_read_byte(username) != 0) {
     p = stringprint(p, username);
   }
-  if (pgm_read_byte(password) != 0) {
+  if (!(nullString.equals(password)) && pgm_read_byte(password) != 0) {
     p = stringprint(p, password);
   }
 


### PR DESCRIPTION
Under the function "connectPacket()", I've added "nullString" and appropriate check conditions to allow the users to send messages to unauthenticated MQTT brokers, that don't require usernames and passwords.  This is great for testing that the project works by sending messages to basic brokers, self-hosted or otherwise.   Please test and review!

Added a check condition in case the username and password are equal to "" in the .ino file.  For example, connection to test.mosquitto.org requires no authentication.  This allows ease of use for simply testing that the arduino and fona are working properly together.   Tested to function on an arduino uno, with a fona 808, sending test messages to test.mosquitto.org:1883.

Without the check condition, and the username and password set to "", the library still asserts the MQTT_CONN_USERNAMEFLAG and MQTT_CONN_PASSWORDFLAG flags, and extends the overall header by four bytes.  

Example packet:
0x10 0x10 0x0 0x4 0x4D 0x51 0x54 0x54 0x4 0xFFFFFFC2 0x1 0x2C 0x0 0x0 0x0 0x0 0x0 0x0
Corrected packet:
0x10 0xC 0x0 0x4 0x4D 0x51 0x54 0x54 0x4 0x2 0x1 0x2C 0x0 0x0

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
