### PR TITLE
update ssl fingerprint in example

### DIFF
--- a/examples/adafruitio_secure_esp8266/adafruitio_secure_esp8266.ino
+++ b/examples/adafruitio_secure_esp8266/adafruitio_secure_esp8266.ino
@@ -41,7 +41,7 @@ WiFiClientSecure client;
 Adafruit_MQTT_Client mqtt(&client, AIO_SERVER, AIO_SERVERPORT, AIO_USERNAME, AIO_KEY);
 
 // io.adafruit.com SHA1 fingerprint
-const char* fingerprint = "AD 4B 64 B3 67 40 B5 FC 0E 51 9B BD 25 E9 7F 88 B6 2A A3 5B";
+const char* fingerprint = "77 00 54 2D DA E7 D8 03 27 31 23 99 EB 27 DB CB A5 4C 57 18";
 
 /****************************** Feeds ***************************************/
 


### PR DESCRIPTION
Updates the fingerprint to the current value from the ssl certificate of io.adafruit.com in the adafruitio_secure_esp8266.ino example.