### PR TITLE
remove CC3000 from keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,4 @@
 Adafruit_MQTT	KEYWORD1
-Adafruit_MQTT_CC3000	KEYWORD1
 Adafruit_MQTT_FONA	KEYWORD1
 Adafruit_MQTT_Client	KEYWORD1
 Adafruit_MQTT_Publish	KEYWORD1


### PR DESCRIPTION
small pr - removing left-over reference to ADAFRUIT_MQTT_CC3000 (unsupported by this library) in `keywords.txt`