### PR TITLE
Update for M4 hardware

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -21,7 +21,7 @@
 // SOFTWARE.
 #include "Adafruit_MQTT.h"
 
-#if defined(ARDUINO_SAMD_ZERO) || defined(ARDUINO_SAMD_MKR1000)
+#if defined(ARDUINO_SAMD_ZERO) || defined(ARDUINO_SAMD_MKR1000) || defined(ARDUINO_ARCH_SAMD)
 static char *dtostrf (double val, signed char width, unsigned char prec, char *sout) {
   char fmt[20];
   sprintf(fmt, "%%%d.%df", width, prec);


### PR DESCRIPTION
Adding IFDEF to include `*dtostrf` function when compiling for M4 hardware. I could also replace ARDUINO_SAMD_ZERO with ARDUINO_ARCH_SAMD?

Tested with PyPortal and nina-fw's WiFiClient connecting to Adafruit.IO. 

