### PR TITLE
packets are dropped after connect if retain is set on server

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -172,6 +172,9 @@ int8_t Adafruit_MQTT::connect() {
 
     boolean success = false;
     for (uint8_t retry=0; (retry<3) && !success; retry++) { // retry until we get a suback    
+      // read possible retain packets - sent after two or more subscriptions
+      processPackets(SUBACK_TIMEOUT_MS);
+
       // Construct and send subscription packet.
       uint8_t len = subscribePacket(buffer, subscriptions[i]->topic, subscriptions[i]->qos);
       if (!sendPacket(buffer, len))


### PR DESCRIPTION
add barrier in connect() function for processing MQTT subscriptions packets which are sent with retain bit in subscriptions
fixes "Dropped a packet" after connect with two or more subscriptions active

client view:
> send connect
< receive connect
> subscribe
< suback
> subscribe
< illegal packet
< suback
> subscribe
< illegal packet
< suback

server view:
< send connect
> receive connect
< subscribe
> suback
> send subscription update (retain value)
< subscribe
< suback
> send subscription update (retain value)
< subscribe
> suback
> send subscription update (retain value)

So the server sends the last retain value, which is processed after new subscription but the client expects a SUBACK packet and not a publish one. This happens only on multiple subscriptions at connect.

Disadvantages:
- spend 500ms more in connection for each subscription. (see define)