### PR TITLE
Removed all occurences of pgm_read_byte

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -578,7 +578,7 @@ uint8_t Adafruit_MQTT::connectPacket(uint8_t *packet) {
   p[0] = MQTT_CONN_CLEANSESSION;
 
   // set the will flags if needed
-  if (will_topic && pgm_read_byte(will_topic) != 0) {
+  if (will_topic && will_topic[0] != '\0') {
 
     p[0] |= MQTT_CONN_WILLFLAG;
 
@@ -592,9 +592,9 @@ uint8_t Adafruit_MQTT::connectPacket(uint8_t *packet) {
 
   }
 
-  if (pgm_read_byte(username) != 0)
+  if (username[0] != '\0')
     p[0] |= MQTT_CONN_USERNAMEFLAG;
-  if (pgm_read_byte(password) != 0)
+  if (password[0] != '\0')
     p[0] |= MQTT_CONN_PASSWORDFLAG;
   p++;
 
@@ -606,7 +606,7 @@ uint8_t Adafruit_MQTT::connectPacket(uint8_t *packet) {
   if(MQTT_PROTOCOL_LEVEL == 3) {
     p = stringprint(p, clientid, 23);  // Limit client ID to first 23 characters.
   } else {
-    if (pgm_read_byte(clientid) != 0) {
+    if (clientid[0] != '\0') {
       p = stringprint(p, clientid);
     } else {
       p[0] = 0x0;
@@ -617,15 +617,15 @@ uint8_t Adafruit_MQTT::connectPacket(uint8_t *packet) {
     }
   }
 
-  if (will_topic && pgm_read_byte(will_topic) != 0) {
+  if (will_topic && will_topic[0] != '\0') {
     p = stringprint(p, will_topic);
     p = stringprint(p, will_payload);
   }
 
-  if (pgm_read_byte(username) != 0) {
+  if (username[0] != '\0') {
     p = stringprint(p, username);
   }
-  if (pgm_read_byte(password) != 0) {
+  if (password[0] != '\0') {
     p = stringprint(p, password);
   }
 


### PR DESCRIPTION
Hello Adafruit,

after some deep diving in this library's source code that you are so kind to provide and which, by the way, does an awesome job together with your FONA module and Adafruit IO, I found an remnant of the times where user authentication data were still saved in PROGMEM. Unfortunately, these 7 occurences of pgm_read_byte that are still there have gone unnoticed until today. They only cause problems if one tries to comment out `#define MQTT_DEBUG`. I won't go into detail but I think that these small adjustments will help some people as this will potentially solve issue #54.

I hope that this library is still being maintained.
Thank you!
eutill