### PR TITLE
Corrected client public/private methods.

### DIFF
--- a/Adafruit_MQTT_Client.h
+++ b/Adafruit_MQTT_Client.h
@@ -41,11 +41,14 @@ public:
                        const char *user = "", const char *pass = "")
       : Adafruit_MQTT(server, port, user, pass), client(client) {}
 
-  bool connectServer();
-  bool disconnectServer();
-  bool connected();
-  uint16_t readPacket(uint8_t *buffer, uint16_t maxlen, int16_t timeout);
-  bool sendPacket(uint8_t *buffer, uint16_t len);
+  bool connected() override;
+
+protected:
+  bool connectServer() override;
+  bool disconnectServer() override;
+  uint16_t readPacket(uint8_t *buffer, uint16_t maxlen,
+                      int16_t timeout) override;
+  bool sendPacket(uint8_t *buffer, uint16_t len) override;
 
 private:
   Client *client;

--- a/Adafruit_MQTT_FONA.h
+++ b/Adafruit_MQTT_FONA.h
@@ -42,7 +42,13 @@ public:
                      const char *user = "", const char *pass = "")
       : Adafruit_MQTT(server, port, user, pass), fona(f) {}
 
-  bool connectServer() {
+  bool connected() {
+    // Return true if connected, false if not connected.
+    return fona->TCPconnected();
+  }
+
+protected:
+  bool connectServer() override {
     char server[40];
     strncpy(server, servername, 40);
 #ifdef ADAFRUIT_SLEEPYDOG_H
@@ -54,14 +60,10 @@ public:
     return fona->TCPconnect(server, portnum);
   }
 
-  bool disconnectServer() { return fona->TCPclose(); }
+  bool disconnectServer() override { return fona->TCPclose(); }
 
-  bool connected() {
-    // Return true if connected, false if not connected.
-    return fona->TCPconnected();
-  }
-
-  uint16_t readPacket(uint8_t *buffer, uint16_t maxlen, int16_t timeout) {
+  uint16_t readPacket(uint8_t *buffer, uint16_t maxlen,
+                      int16_t timeout) override {
     uint8_t *buffp = buffer;
     DEBUG_PRINTLN(F("Reading data.."));
 
@@ -114,7 +116,7 @@ public:
     return len;
   }
 
-  bool sendPacket(uint8_t *buffer, uint16_t len) {
+  bool sendPacket(uint8_t *buffer, uint16_t len) override {
     DEBUG_PRINTLN(F("Writing packet"));
     if (fona->TCPconnected()) {
       boolean ret = fona->TCPsend((char *)buffer, len);


### PR DESCRIPTION
Switched the following four methods from public to
protected in Adafruit_MQTT_Client and Adafruit_MQTT_FONA:

1. connectServer
2. disconnectServer
3. readPacket
4. sendPacket

When public (previously) they could be called by users
of this library, which is not the intent of this API.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
