### PR TITLE
Added support for the MKR1010

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -21,7 +21,7 @@
 // SOFTWARE.
 #include "Adafruit_MQTT.h"
 
-#if defined(ARDUINO_SAMD_ZERO) || defined(ARDUINO_SAMD_MKR1000) ||             \
+#if defined(ARDUINO_SAMD_ZERO) || defined(ARDUINO_SAMD_MKR1000) || defined(ARDUINO_SAMD_MKR1010) ||             \
     defined(ARDUINO_ARCH_SAMD)
 static char *dtostrf(double val, signed char width, unsigned char prec,
                      char *sout) {

--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -21,8 +21,8 @@
 // SOFTWARE.
 #include "Adafruit_MQTT.h"
 
-#if defined(ARDUINO_SAMD_ZERO) || defined(ARDUINO_SAMD_MKR1000) || defined(ARDUINO_SAMD_MKR1010) ||             \
-    defined(ARDUINO_ARCH_SAMD)
+#if defined(ARDUINO_SAMD_ZERO) || defined(ARDUINO_SAMD_MKR1000) ||             \
+    defined(ARDUINO_SAMD_MKR1010) || defined(ARDUINO_ARCH_SAMD)
 static char *dtostrf(double val, signed char width, unsigned char prec,
                      char *sout) {
   char fmt[20];


### PR DESCRIPTION
Added "defined(ARDUINO_SAMD_MKR1010)" into line 24 of Adafruit_MQTT.ccp to add support for the Arduino MKR1010 WiFi.
