### PR TITLE
connectPacket: send a second length-byte if payload is larger than >127 Byte

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -662,7 +662,15 @@ uint8_t Adafruit_MQTT::connectPacket(uint8_t *packet) {
 
   len = p - packet;
 
-  packet[1] = len - 2; // don't include the 2 bytes of fixed header data
+  if (len > (127 + 2)) {
+    packet[1] = ((len - 2) % 128) + 0x80; // LSB
+    memmove(packet + 3, packet + 2, len - 2); // create space for an additional length-byte
+    packet[2] = (len - 2) / 128; // MSB
+    len++;
+  } else {
+    packet[1] = len - 2; // don't include the 2 bytes of fixed header data
+  }
+
   DEBUG_PRINTLN(F("MQTT connect packet:"));
   DEBUG_PRINTBUFFER(buffer, len);
   return len;


### PR DESCRIPTION
The connectPacket-method of Adafruit_MQTT uses only one byte for the remaining-length-field of the CONNECT-Packet.
If the Packet is greater than 127 Byte, an invalid packet is sent, as the highest bit is set, but no additional length-byte is added.
This PR adds code which checks the length and adds one byte if necessary.
The MQTT-Protocol allows up to 4 bytes for the length-field, but as the buffer is currently limited to 150 Byte, I only use up to 2 Bytes.
I tested the code on an ESP8266, but it should work for other platforms too.

I had the same issue like #108. topic/message of last-will are send in the CONNECT-Packet, which caused the Packet to be larger than 127 Byte, and triggered the bug.