### PR TITLE
Support publishing and receiving large messages.

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -96,6 +96,22 @@ static uint8_t *stringprint(uint8_t *p, const char *s, uint16_t maxlen = 0) {
   return p + len;
 }
 
+// packetAdditionalLen is a helper function used to figure out
+// how bigger the payload needs to be in order to account for
+// its variable length field. As per
+// http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Table_2.4_Size
+// See also readFullPacket
+static uint16_t packetAdditionalLen(uint32_t currLen) {
+  /* Increase length field based on current length */
+  if (currLen < 128) // 7-bits
+    return 0;
+  if (currLen < 16384) // 14-bits
+    return 1;
+  if (currLen < 2097152) // 21-bits
+    return 2;
+  return 3;
+}
+
 // Adafruit_MQTT Definition ////////////////////////////////////////////////////
 
 Adafruit_MQTT::Adafruit_MQTT(const char *server, uint16_t port, const char *cid,
@@ -267,7 +283,8 @@ uint16_t Adafruit_MQTT::readFullPacket(uint8_t *buffer, uint16_t maxsize,
   DEBUG_PRINT(F("Packet Length:\t"));
   DEBUG_PRINTLN(value);
 
-  if (value > (maxsize - (pbuff - buffer) - 1)) {
+  // maxsize is limited to 65536 by 16-bit unsigned
+  if (value > uint32_t(maxsize - (pbuff - buffer) - 1)) {
     DEBUG_PRINTLN(F("Packet too big for buffer"));
     rlen = readPacket(pbuff, (maxsize - (pbuff - buffer) - 1), timeout);
   } else {
@@ -474,22 +491,6 @@ Adafruit_MQTT_Subscribe *Adafruit_MQTT::readSubscription(int16_t timeout) {
   return handleSubscriptionPacket(len);
 }
 
-namespace {
-
-uint16_t topicOffsetFromLength(uint16_t const len) 
-{
-  if (len < 128) {            // 7 bits (+1 continuation bit)
-    return 0;
-  } else if (len < 16384) {   // 14 bits (+2 continuation bits)
-    return 1;
-  } else if (len < 2097152) { // 21 bits
-    return 2;
-  }
-  return 3;
-}
-
-} // anon
-
 Adafruit_MQTT_Subscribe *Adafruit_MQTT::handleSubscriptionPacket(uint16_t len) {
   uint16_t i, topiclen, datalen;
 
@@ -508,9 +509,9 @@ Adafruit_MQTT_Subscribe *Adafruit_MQTT::handleSubscriptionPacket(uint16_t len) {
   }
 
   // Parse out length of packet.
-  uint16_t const topicoffset = topicOffsetFromLength(len);
+  uint16_t const topicoffset = packetAdditionalLen(len);
   uint16_t const topicstart = topicoffset + 4;
-  topiclen = buffer[3+topicoffset];
+  topiclen = buffer[3 + topicoffset];
   DEBUG_PRINT(F("Looking for subscription len "));
   DEBUG_PRINTLN(topiclen);
 
@@ -523,8 +524,8 @@ Adafruit_MQTT_Subscribe *Adafruit_MQTT::handleSubscriptionPacket(uint16_t len) {
         continue;
       // Stop if the subscription topic matches the received topic. Be careful
       // to make comparison case insensitive.
-      if (strncasecmp((char *)buffer + topicstart, subscriptions[i]->topic, topiclen) ==
-          0) {
+      if (strncasecmp((char *)buffer + topicstart, subscriptions[i]->topic,
+                      topiclen) == 0) {
         DEBUG_PRINT(F("Found sub #"));
         DEBUG_PRINTLN(i);
         break;
@@ -552,8 +553,8 @@ Adafruit_MQTT_Subscribe *Adafruit_MQTT::handleSubscriptionPacket(uint16_t len) {
     datalen = SUBSCRIPTIONDATALEN - 1; // cut it off
   }
   // extract out just the data, into the subscription object itself
-  memmove(subscriptions[i]->lastread, buffer + topicstart + topiclen + packet_id_len,
-          datalen);
+  memmove(subscriptions[i]->lastread,
+          buffer + topicstart + topiclen + packet_id_len, datalen);
   subscriptions[i]->datalen = datalen;
   DEBUG_PRINT(F("Data len: "));
   DEBUG_PRINTLN(datalen);
@@ -685,21 +686,6 @@ uint8_t Adafruit_MQTT::connectPacket(uint8_t *packet) {
   DEBUG_PRINTLN(F("MQTT connect packet:"));
   DEBUG_PRINTBUFFER(buffer, len);
   return len;
-}
-
-// packetAdditionalLen is a helper function used to figure out
-// how bigger the payload needs to be in order to account for
-// its variable length field. As per
-// http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Table_2.4_Size
-static uint16_t packetAdditionalLen(uint16_t currLen) {
-  /* Increase length field based on current length */
-  if (currLen < 128)
-    return 0;
-  if (currLen < 16384)
-    return 1;
-  if (currLen < 2097151)
-    return 2;
-  return 3;
 }
 
 // as per

--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -475,7 +475,7 @@ Adafruit_MQTT_Subscribe *Adafruit_MQTT::readSubscription(int16_t timeout) {
 
 namespace {
 
-uint16_t topicOffsetFromLenth(uint16_t const len) 
+uint16_t topicOffsetFromLength(uint16_t const len) 
 {
   if (len < 128) {            // 7 bits (+1 continuation bit)
     return 0;

--- a/Adafruit_MQTT_Client.cpp
+++ b/Adafruit_MQTT_Client.cpp
@@ -95,7 +95,7 @@ bool Adafruit_MQTT_Client::sendPacket(uint8_t *buffer, uint16_t len) {
       DEBUG_PRINTLN(ret);
       len -= ret;
       offset += ret;
-      
+
       if (ret != sendlen) {
         DEBUG_PRINTLN("Failed to send packet.");
         return false;

--- a/Adafruit_MQTT_Client.cpp
+++ b/Adafruit_MQTT_Client.cpp
@@ -83,18 +83,19 @@ uint16_t Adafruit_MQTT_Client::readPacket(uint8_t *buffer, uint16_t maxlen,
 
 bool Adafruit_MQTT_Client::sendPacket(uint8_t *buffer, uint16_t len) {
   uint16_t ret = 0;
-
+  uint16_t offset = 0;
   while (len > 0) {
     if (client->connected()) {
       // send 250 bytes at most at a time, can adjust this later based on Client
 
       uint16_t sendlen = len > 250 ? 250 : len;
       // Serial.print("Sending: "); Serial.println(sendlen);
-      ret = client->write(buffer, sendlen);
+      ret = client->write(buffer + offset, sendlen);
       DEBUG_PRINT(F("Client sendPacket returned: "));
       DEBUG_PRINTLN(ret);
       len -= ret;
-
+      offset += ret;
+      
       if (ret != sendlen) {
         DEBUG_PRINTLN("Failed to send packet.");
         return false;

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MQTT Library
-version=2.2.0
+version=2.3.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=MQTT library that supports the FONA, ESP8266, Yun, and generic Arduino Client hardware.


### PR DESCRIPTION
Send multiple 250 byte packets for a large message (this was proposed in [PR113](https://github.com/adafruit/Adafruit_MQTT_Library/pull/113), but the change here should work for existing implementations that only support 250 byte packets by breaking the message into chunks).

Correctly identify topic start position for >127byte messages (may also be addressed in [PR166](https://github.com/adafruit/Adafruit_MQTT_Library/pull/166) -- happy to merge that fix in if preferred). 

Resolves [issue 102](https://github.com/adafruit/Adafruit_MQTT_Library/issues/102).

Tested on Wemos D1 mini (ESP8266) with messages up to 1023 bytes (set MAXBUFFERSIZE and SUBSCRIPTIONDATALEN to 1024).


