### PR TITLE
Add setKeepAliveInterval() setter

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -132,6 +132,8 @@ Adafruit_MQTT::Adafruit_MQTT(const char *server, uint16_t port, const char *cid,
   will_qos = 0;
   will_retain = 0;
 
+  keepAliveInterval = MQTT_CONN_KEEPALIVE;
+
   packet_id_counter = 0;
 }
 
@@ -152,6 +154,8 @@ Adafruit_MQTT::Adafruit_MQTT(const char *server, uint16_t port,
   will_payload = 0;
   will_qos = 0;
   will_retain = 0;
+
+  keepAliveInterval = MQTT_CONN_KEEPALIVE;
 
   packet_id_counter = 0;
 }
@@ -381,6 +385,25 @@ bool Adafruit_MQTT::will(const char *topic, const char *payload, uint8_t qos,
   will_qos = qos;
   will_retain = retain;
 
+  return true;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Sets the connect packet's KeepAlive Interval, in seconds. This
+            function MUST be called prior to connect().
+    @param    keepAlive
+               Maximum amount of time without communication between the
+               client and the MQTT broker, in seconds.
+    @returns  True if called prior to connect(), False otherwise.
+*/
+/**************************************************************************/
+bool Adafruit_MQTT::setKeepAliveInterval(uint16_t keepAlive) {
+  if (connected()) {
+    DEBUG_PRINT(F("keepAlive defined after connection established."));
+    return false;
+  }
+  keepAliveInterval = keepAlive;
   return true;
 }
 
@@ -649,9 +672,9 @@ uint8_t Adafruit_MQTT::connectPacket(uint8_t *packet) {
     p[0] |= MQTT_CONN_PASSWORDFLAG;
   p++;
 
-  p[0] = MQTT_CONN_KEEPALIVE >> 8;
+  p[0] = keepAliveInterval >> 8;
   p++;
-  p[0] = MQTT_CONN_KEEPALIVE & 0xFF;
+  p[0] = keepAliveInterval & 0xFF;
   p++;
 
   if (MQTT_PROTOCOL_LEVEL == 3) {

--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -388,7 +388,7 @@ bool Adafruit_MQTT::will(const char *topic, const char *payload, uint8_t qos,
   return true;
 }
 
-/**************************************************************************/
+/***************************************************************************/
 /*!
     @brief  Sets the connect packet's KeepAlive Interval, in seconds. This
             function MUST be called prior to connect().
@@ -397,7 +397,7 @@ bool Adafruit_MQTT::will(const char *topic, const char *payload, uint8_t qos,
                client and the MQTT broker, in seconds.
     @returns  True if called prior to connect(), False otherwise.
 */
-/**************************************************************************/
+/***************************************************************************/
 bool Adafruit_MQTT::setKeepAliveInterval(uint16_t keepAlive) {
   if (connected()) {
     DEBUG_PRINT(F("keepAlive defined after connection established."));

--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -253,7 +253,7 @@ protected:
   const char *will_payload;
   uint8_t will_qos;
   uint8_t will_retain;
-  uint16_t keepAliveInterval; // MQTT KeepAlive time interval, in seconds
+  uint16_t keepAliveInterval;    // MQTT KeepAlive time interval, in seconds
   uint8_t buffer[MAXBUFFERSIZE]; // one buffer, used for all incoming/outgoing
   uint16_t packet_id_counter;
 

--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -184,6 +184,9 @@ public:
   bool will(const char *topic, const char *payload, uint8_t qos = 0,
             uint8_t retain = 0);
 
+  // Sets the KeepAlive Interval, in seconds.
+  bool setKeepAliveInterval(uint16_t keepAlive);
+
   // Publish a message to a topic using the specified QoS level.  Returns true
   // if the message was published, false otherwise.
   bool publish(const char *topic, const char *payload, uint8_t qos = 0);
@@ -250,6 +253,7 @@ protected:
   const char *will_payload;
   uint8_t will_qos;
   uint8_t will_retain;
+  uint16_t keepAliveInterval; // MQTT KeepAlive time interval, in seconds
   uint8_t buffer[MAXBUFFERSIZE]; // one buffer, used for all incoming/outgoing
   uint16_t packet_id_counter;
 

--- a/library.properties
+++ b/library.properties
@@ -1,8 +1,8 @@
 name=Adafruit MQTT Library
-version=2.3.0
+version=2.4.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
-sentence=MQTT library that supports the FONA, ESP8266, Yun, and generic Arduino Client hardware.
+sentence=MQTT library that supports the FONA, ESP8266, ESP32, Yun, and generic Arduino Client hardware.
 paragraph=Simple MQTT library that supports the bare minimum to publish and subscribe to topics.
 category=Communication
 url=https://github.com/adafruit/Adafruit_MQTT_Library


### PR DESCRIPTION
Allows the user to set the MQTT connection's keep alive interval time period in seconds via `setKeepAliveInterval()`. Previously, this time period was defined in the header. The function also checks if `connect()` was called prior.

Addresses https://github.com/adafruit/Adafruit_MQTT_Library/issues/186

Tested with multiple time intervals against Adafruit IO.