### PR TITLE
Fix: Subscriptions can't be read if arrive when waiting for response of ping or publish

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -510,7 +510,7 @@ void Adafruit_MQTT::processPackets(int16_t timeout) {
 Adafruit_MQTT_Subscribe *Adafruit_MQTT::readSubscription(int16_t timeout) {
 
   // Sync or Async subscriber with message
-  Adafruit_MQTT_Subscribe *s=0;
+  Adafruit_MQTT_Subscribe *s = 0;
 
   // Check if are unread messages
   for (uint8_t i = 0; i < MAXSUBSCRIPTIONS; i++) {
@@ -524,7 +524,7 @@ Adafruit_MQTT_Subscribe *Adafruit_MQTT::readSubscription(int16_t timeout) {
   if (!s) {
     // Check if data is available to read.
     uint16_t len = readFullPacket(buffer, MAXBUFFERSIZE,
-		                  timeout); // return one full packet
+                                  timeout); // return one full packet
     s = handleSubscriptionPacket(len);
   }
 

--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -510,27 +510,27 @@ void Adafruit_MQTT::processPackets(int16_t timeout) {
 Adafruit_MQTT_Subscribe *Adafruit_MQTT::readSubscription(int16_t timeout) {
 
   // Sync or Async subscriber with message
-  Adafruit_MQTT_Subscribe* s=0;
+  Adafruit_MQTT_Subscribe *s=0;
 
   // Check if are unread messages
   for (uint8_t i = 0; i < MAXSUBSCRIPTIONS; i++) {
     if (subscriptions[i] && subscriptions[i]->new_message) {
-      s=subscriptions[i];
+      s = subscriptions[i];
       break;
     }
   }
 
   // not unread message
-  if ( ! s ) {
+  if (!s) {
     // Check if data is available to read.
-    uint16_t len = 
-      readFullPacket(buffer, MAXBUFFERSIZE, timeout); // return one full packet
-    s=handleSubscriptionPacket(len);
+    uint16_t len = readFullPacket(buffer, MAXBUFFERSIZE,
+		                  timeout); // return one full packet
+    s = handleSubscriptionPacket(len);
   }
 
   // it there is a message, mark it as not pending
-  if ( s ) {
-    s->new_message=false;
+  if (s) {
+    s->new_message = false;
   }
 
   return s;
@@ -573,12 +573,12 @@ Adafruit_MQTT_Subscribe *Adafruit_MQTT::handleSubscriptionPacket(uint16_t len) {
                       topiclen) == 0) {
         DEBUG_PRINT(F("Found sub #"));
         DEBUG_PRINTLN(i);
-        if ( subscriptions[i]->new_message ) {
+        if (subscriptions[i]->new_message) {
           DEBUG_PRINTLN(F("Lost previous message"));
         } else {
-          subscriptions[i]->new_message=true;
+          subscriptions[i]->new_message = true;
         }
-        
+
         break;
       }
     }

--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -351,13 +351,13 @@ bool Adafruit_MQTT::publish(const char *topic, uint8_t *data, uint16_t bLen,
 
   // If QOS level is high enough verify the response packet.
   if (qos > 0) {
-    len = readFullPacket(buffer, MAXBUFFERSIZE, PUBLISH_TIMEOUT_MS);
+    len = processPacketsUntil(buffer, MQTT_CTRL_PUBACK, PUBLISH_TIMEOUT_MS);
+
     DEBUG_PRINT(F("Publish QOS1+ reply:\t"));
     DEBUG_PRINTBUFFER(buffer, len);
     if (len != 4)
       return false;
-    if ((buffer[0] >> 4) != MQTT_CTRL_PUBACK)
-      return false;
+
     uint16_t packnum = buffer[2];
     packnum <<= 8;
     packnum |= buffer[3];
@@ -508,10 +508,32 @@ void Adafruit_MQTT::processPackets(int16_t timeout) {
   }
 }
 Adafruit_MQTT_Subscribe *Adafruit_MQTT::readSubscription(int16_t timeout) {
-  // Check if data is available to read.
-  uint16_t len =
+
+  // Sync or Async subscriber with message
+  Adafruit_MQTT_Subscribe* s=0;
+
+  // Check if are unread messages
+  for (uint8_t i = 0; i < MAXSUBSCRIPTIONS; i++) {
+    if (subscriptions[i] && subscriptions[i]->new_message) {
+      s=subscriptions[i];
+      break;
+    }
+  }
+
+  // not unread message
+  if ( ! s ) {
+    // Check if data is available to read.
+    uint16_t len = 
       readFullPacket(buffer, MAXBUFFERSIZE, timeout); // return one full packet
-  return handleSubscriptionPacket(len);
+    s=handleSubscriptionPacket(len);
+  }
+
+  // it there is a message, mark it as not pending
+  if ( s ) {
+    s->new_message=false;
+  }
+
+  return s;
 }
 
 Adafruit_MQTT_Subscribe *Adafruit_MQTT::handleSubscriptionPacket(uint16_t len) {
@@ -551,6 +573,12 @@ Adafruit_MQTT_Subscribe *Adafruit_MQTT::handleSubscriptionPacket(uint16_t len) {
                       topiclen) == 0) {
         DEBUG_PRINT(F("Found sub #"));
         DEBUG_PRINTLN(i);
+        if ( subscriptions[i]->new_message ) {
+          DEBUG_PRINTLN(F("Lost previous message"));
+        } else {
+          subscriptions[i]->new_message=true;
+        }
+        
         break;
       }
     }
@@ -910,6 +938,7 @@ Adafruit_MQTT_Subscribe::Adafruit_MQTT_Subscribe(Adafruit_MQTT *mqttserver,
   callback_double = 0;
   callback_io = 0;
   io_mqtt = 0;
+  new_message = false;
 }
 
 void Adafruit_MQTT_Subscribe::setCallback(SubscribeCallbackUInt32Type cb) {

--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -320,6 +320,8 @@ public:
 
   AdafruitIO_MQTT *io_mqtt;
 
+  bool new_message;
+
 private:
   Adafruit_MQTT *mqtt;
 };


### PR DESCRIPTION
When I'm working with the library, I detect that some event was lost. After enabled debug, I've detected 2 situations:

1. Ping call processPacketsUntil which detect if call new message (appears in debug console), but can't be read in callback or readSubscription.
My fix add a boolean attribute "new_message" (default false) in Adafruit_MQTT_Publish class. It is set to true inside processPacketsUntil. Later, in readSubscription, search if there are pending message. If so, return that message.
Callback don't need to be modified because it call readSubscription.

1. Sometimes my program fail to publish a message and loss subscription arrived (detected in debug console). The fix was more easy and clean: replase readFullPacket with processPacketsUntil. This permit that a message arrive when waiting for response on QoS>0 and because processPacketsUntil has the expected packet type, the check in the type in buffer is not needed anymore.

### Logs

1. PING

```
MQTT ping packet:
          [0xC0],   [0x00], 
Client sendPacket returned: 2
Read data:              2 [0x32], 
Packet Type:            2 [0x32],
Read data:                [0x1A], 
Packet Length:  26
Read data:                [0x00],   [0x14], e [0x65], s [0x73], p [0x70], - [0x2D], p [0x70], r [0x72],
        u [0x75], e [0x65], b [0x62], a [0x61], / [0x2F], l [0x6C], u [0x75], z [0x7A],
        / [0x2F], r [0x72], o [0x6F], j [0x6A], o [0x6F], 2 [0x32],   [0x00],   [0x1F],
        O [0x4F], N [0x4E],
Packet len: 28
        2 [0x32],   [0x1A],   [0x00],   [0x14], e [0x65], s [0x73], p [0x70], - [0x2D],
        p [0x70], r [0x72], u [0x75], e [0x65], b [0x62], a [0x61], / [0x2F], l [0x6C],
        u [0x75], z [0x7A], / [0x2F], r [0x72], o [0x6F], j [0x6A], o [0x6F], 2 [0x32],
          [0x00],   [0x1F], O [0x4F], N [0x4E],
Looking for subscription len 20
Found sub #4
Data len: 2
Data: ON
MQTT puback packet:
        2 [0x32],   [0x1A],   [0x00],   [0x14],
Client sendPacket returned: 4
Read data:                [0xD0],
Packet Type:              [0xD0],
Read data:                [0x00],
Packet Length:  0
```
message are parsed, but never read

2. PUBLISH
```
MQTT publish packet:
        2 [0x32], ' [0x27],   [0x00],   [0x17], e [0x65], s [0x73], p [0x70], - [0x2D],
        p [0x70], r [0x72], u [0x75], e [0x65], b [0x62], a [0x61], / [0x2F], f [0x66],
        e [0x65], e [0x65], d [0x64], s [0x73], / [0x2F], e [0x65], s [0x73], t [0x74],
        a [0x61], d [0x64], o [0x6F],   [0x00],   [0x0D], 1 [0x31], 9 [0x39], 2 [0x32],
        . [0x2E], 1 [0x31], 6 [0x36], 8 [0x38], . [0x2E], 0 [0x30], . [0x2E], 6 [0x36],
        1 [0x31],
Client sendPacket returned: 41
Read data:              2 [0x32],
Packet Type:            2 [0x32],
Read data:                [0x1A],
Packet Length:  26
Read data:                [0x00],   [0x14], e [0x65], s [0x73], p [0x70], - [0x2D], p [0x70], r [0x72],
        u [0x75], e [0x65], b [0x62], a [0x61], / [0x2F], l [0x6C], u [0x75], z [0x7A],
        / [0x2F], r [0x72], o [0x6F], j [0x6A], o [0x6F], 2 [0x32],   [0x00],   [0x03],
        O [0x4F], N [0x4E],
Publish QOS1+ reply:            2 [0x32],   [0x1A],   [0x00],   [0x14], e [0x65], s [0x73], p [0x70], - [0x2D],
        p [0x70], r [0x72], u [0x75], e [0x65], b [0x62], a [0x61], / [0x2F], l [0x6C],
        u [0x75], z [0x7A], / [0x2F], r [0x72], o [0x6F], j [0x6A], o [0x6F], 2 [0x32],
          [0x00],   [0x03], O [0x4F], N [0x4E],
Failed <--- return of publish is false
Read data:              @ [0x40],
Packet Type:            @ [0x40],
Read data:                [0x02],
Packet Length:  2
Read data:                [0x00],   [0x0D],
Packet len: 4
        @ [0x40],   [0x02],   [0x00],   [0x0D],
```
On publish waiting por ACK, ignore incomming messages and return an error because ACK come later.
