### PR TITLE
Fixed length calculation when payload exceeds 128bytes

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -733,7 +733,8 @@ uint16_t Adafruit_MQTT::publishPacket(uint8_t *packet, const char *topic,
   // 2 + additionalLen: header byte + remaining length field (from 1 to 4 bytes)
   // len = topic size field + value (string)
   // bLen = buffer size
-  if (!(maxPacketLen == 0 || (len + bLen + 2 + additionalLen <= maxPacketLen))) {
+  if (!(maxPacketLen == 0 ||
+        (len + bLen + 2 + additionalLen <= maxPacketLen))) {
     // If we make it here, we got a pickle: the payload is not going
     // to fit in the packet buffer. Instead of corrupting memory, let's
     // do something less damaging by reducing the bLen to what we are

--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -728,19 +728,20 @@ uint16_t Adafruit_MQTT::publishPacket(uint8_t *packet, const char *topic,
   // Calculate additional bytes for length field (if any)
   uint16_t additionalLen = packetAdditionalLen(len + bLen);
 
-  // Payload length. When maxPacketLen provided is 0, let's
+  // Payload remaining length. When maxPacketLen provided is 0, let's
   // assume buffer is big enough. Fingers crossed.
-  if (maxPacketLen == 0 || (len + bLen + 2 + additionalLen <= maxPacketLen)) {
-    len += bLen + additionalLen;
-  } else {
+  // 2 + additionalLen: header byte + remaining length field (from 1 to 4 bytes)
+  // len = topic size field + value (string)
+  // bLen = buffer size
+  if (!(maxPacketLen == 0 || (len + bLen + 2 + additionalLen <= maxPacketLen))) {
     // If we make it here, we got a pickle: the payload is not going
     // to fit in the packet buffer. Instead of corrupting memory, let's
     // do something less damaging by reducing the bLen to what we are
     // able to accomodate. Alternatively, consider using a bigger
     // maxPacketLen.
     bLen = maxPacketLen - (len + 2 + packetAdditionalLen(maxPacketLen));
-    len = maxPacketLen - 4;
   }
+  len += bLen; // remaining len excludes header byte & length field
 
   // Now you can start generating the packet!
   p[0] = MQTT_CTRL_PUBLISH << 4 | qos << 1;


### PR DESCRIPTION
Further testing of my recent patch uncovered a new issue: the packet length calculation is off by +1 when the payload size is greater than 128 bytes. This length is stored in the MQTT packet header, so the broker is expecting a packet that is one byte longer than what gets sent (and times out or otherwise fails). The length stored in the MQTT packet header is the "remaining length" (see e.g. http://www.steves-internet-guide.com/mqtt-protocol-messages-overview/) and shouldn't include itself in the calculation. 