### PR TITLE
Increase server name length in MQTT_FONA.h

### DIFF
--- a/Adafruit_MQTT_FONA.h
+++ b/Adafruit_MQTT_FONA.h
@@ -49,8 +49,8 @@ public:
 
 protected:
   bool connectServer() override {
-    char server[40];
-    strncpy(server, servername, 40);
+    char server[60];
+    strncpy(server, servername, 60);
 #ifdef ADAFRUIT_SLEEPYDOG_H
     Watchdog.reset();
 #endif


### PR DESCRIPTION
- Increase the amount of characters to copy server name in the
`connectServer` method from 40 to 60 to allow connecting to servers
with a slightly longer FQDN

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This modifies the server connection funcionality when connecting over GPRS with the FONA library. I updated the MQTT_FONA.h file.

- **Describe any known limitations with your change.**  This will still limit server name FQDN to 60 characters and not allow connections to them.

- **Please run any tests or examples that can exercise your modified code.**  Try to connect to `door-lock-dev.westeurope.azurecontainer.io` on port 1883 to see if you can successfully connect to it. I will leave the connection open to anonymous connections until the pull request is approved. This URL is 42 characters long and before this change connecting to the server was not possible, after I made this change I was able to connect to it
