### PR TITLE
Fix packet identifier

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -340,6 +340,11 @@ bool Adafruit_MQTT::disconnect() {
 bool Adafruit_MQTT::publish(const char *topic, const char *data, uint8_t qos) {
   return publish(topic, (uint8_t *)(data), strlen(data), qos);
 }
+void Adafruit_MQTT::incrementPacketIdCounter() {
+  packet_id_counter++;
+  // Ensure packet_id_counter is never zero
+  packet_id_counter = packet_id_counter == 0 ? 1 : packet_id_counter;
+}
 
 bool Adafruit_MQTT::publish(const char *topic, uint8_t *data, uint16_t bLen,
                             uint8_t qos) {
@@ -365,6 +370,8 @@ bool Adafruit_MQTT::publish(const char *topic, uint8_t *data, uint16_t bLen,
     // we increment the packet_id_counter right after publishing so inc here too
     // to match
     packnum++;
+    if(packnum == 0)
+      packnum = 1;
     if (packnum != packet_id_counter)
       return false;
   }
@@ -798,7 +805,7 @@ uint16_t Adafruit_MQTT::publishPacket(uint8_t *packet, const char *topic,
     p += 2;
 
     // increment the packet id
-    packet_id_counter++;
+    incrementPacketIdCounter();
   }
 
   memmove(p, data, bLen);
@@ -824,7 +831,7 @@ uint8_t Adafruit_MQTT::subscribePacket(uint8_t *packet, const char *topic,
   p += 2;
 
   // increment the packet id
-  packet_id_counter++;
+  incrementPacketIdCounter();
 
   p = stringprint(p, topic);
 
@@ -853,7 +860,7 @@ uint8_t Adafruit_MQTT::unsubscribePacket(uint8_t *packet, const char *topic) {
   p += 2;
 
   // increment the packet id
-  packet_id_counter++;
+  incrementPacketIdCounter();
 
   p = stringprint(p, topic);
 

--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -134,7 +134,7 @@ Adafruit_MQTT::Adafruit_MQTT(const char *server, uint16_t port, const char *cid,
 
   keepAliveInterval = MQTT_CONN_KEEPALIVE;
 
-  packet_id_counter = 0;
+  packet_id_counter = 1;
 }
 
 Adafruit_MQTT::Adafruit_MQTT(const char *server, uint16_t port,
@@ -157,7 +157,7 @@ Adafruit_MQTT::Adafruit_MQTT(const char *server, uint16_t port,
 
   keepAliveInterval = MQTT_CONN_KEEPALIVE;
 
-  packet_id_counter = 0;
+  packet_id_counter = 1;
 }
 
 int8_t Adafruit_MQTT::connect() {

--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -271,6 +271,7 @@ private:
   uint8_t unsubscribePacket(uint8_t *packet, const char *topic);
   uint8_t pingPacket(uint8_t *packet);
   uint8_t pubackPacket(uint8_t *packet, uint16_t packetid);
+  void incrementPacketIdCounter();
 };
 
 class Adafruit_MQTT_Publish {


### PR DESCRIPTION
The MQTT specification requires (Ref: [MQTT-2.3.1-1](https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718025)) that 
> [...] Control Packets MUST contain a ***non-zero*** 16-bit Packet Identifier
The current implementation uses a counter "packet_id_counter", which is set in the constructor to zero.
That causes the first SUBSCRIBE, PUBLISH or UNSUBSCRIBE to cause a disconnect by the broker because of protocol violation.
The packet_id_counter is not reset on reconnect, so after a reconnect everything works normally.
This PR fixes the behavior to:
- start by packet id "1"
- in case of an overflow (i.e. packet id > 65535) to restart at 1
