### PR TITLE
Fix subscription packet callbacks not executing within processPacketsUntil()

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -240,7 +240,8 @@ void Adafruit_MQTT::processSubscriptionPacket(Adafruit_MQTT_Subscribe *sub) {
     // execute callback in io mode
     ((sub->io_mqtt)->*(sub->callback_io))((char *)sub->lastread, sub->datalen);
   } else {
-    DEBUG_PRINTLN("ERROR: Subscription packet did not have an associated callback");
+    DEBUG_PRINTLN(
+        "ERROR: Subscription packet did not have an associated callback");
     return;
   }
   // mark subscription message as "read""

--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -239,6 +239,9 @@ void Adafruit_MQTT::processSubscriptionPacket(Adafruit_MQTT_Subscribe *sub) {
   } else if (sub->callback_io != NULL) {
     // execute callback in io mode
     ((sub->io_mqtt)->*(sub->callback_io))((char *)sub->lastread, sub->datalen);
+  } else {
+    DEBUG_PRINTLN("ERROR: Subscription packet did not have an associated callback");
+    return;
   }
   // mark subscription message as "read""
   sub->new_message = false;

--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -235,7 +235,6 @@ void Adafruit_MQTT::processSubscriptionPacket(Adafruit_MQTT_Subscribe *sub) {
     sub->callback_double(data);
   } else if (sub->callback_buffer != NULL) {
     // execute callback in buffer mode
-    DEBUG_PRINTLN("processPacketsUntil called the callback_buffer!");
     sub->callback_buffer((char *)sub->lastread, sub->datalen);
   } else if (sub->callback_io != NULL) {
     // execute callback in io mode
@@ -249,9 +248,6 @@ uint16_t Adafruit_MQTT::processPacketsUntil(uint8_t *buffer,
                                             uint8_t waitforpackettype,
                                             uint16_t timeout) {
   uint16_t len;
-  DEBUG_PRINTLN("call: processPacketsUntil()");
-  DEBUG_PRINT("Looking for packetType: ");
-  DEBUG_PRINTLN(waitforpackettype);
 
   while (true) {
     len = readFullPacket(buffer, MAXBUFFERSIZE, timeout);
@@ -505,7 +501,6 @@ void Adafruit_MQTT::processPackets(int16_t timeout) {
   uint32_t elapsed = 0, endtime, starttime = millis();
 
   while (elapsed < (uint32_t)timeout) {
-    DEBUG_PRINTLN("L480: readSubscription() called by processPackets()");
     Adafruit_MQTT_Subscribe *sub = readSubscription(timeout - elapsed);
     if (sub)
       processSubscriptionPacket(sub);

--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -209,9 +209,11 @@ public:
   // messages!
   Adafruit_MQTT_Subscribe *readSubscription(int16_t timeout = 0);
 
-  // Handle any data coming in for subscriptions and fires them off to the
-  // appropriate callback
+  // Handle any data coming in for subscriptions
   Adafruit_MQTT_Subscribe *handleSubscriptionPacket(uint16_t len);
+
+  // Execute a subscription packet's associated callback and mark as "read"
+  void processSubscriptionPacket(Adafruit_MQTT_Subscribe *sub);
 
   void processPackets(int16_t timeout);
 

--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -34,7 +34,7 @@
 #define ADAFRUIT_MQTT_VERSION_PATCH 0
 
 // Uncomment/comment to turn on/off debug output messages.
-//#define MQTT_DEBUG
+#define MQTT_DEBUG
 // Uncomment/comment to turn on/off error output messages.
 #define MQTT_ERROR
 
@@ -107,7 +107,7 @@
 // Largest full packet we're able to send.
 // Need to be able to store at least ~90 chars for a connect packet with full
 // 23 char client ID.
-#define MAXBUFFERSIZE (150)
+#define MAXBUFFERSIZE (512)
 
 #define MQTT_CONN_USERNAMEFLAG 0x80
 #define MQTT_CONN_PASSWORDFLAG 0x40

--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -34,7 +34,7 @@
 #define ADAFRUIT_MQTT_VERSION_PATCH 0
 
 // Uncomment/comment to turn on/off debug output messages.
-#define MQTT_DEBUG
+// #define MQTT_DEBUG
 // Uncomment/comment to turn on/off error output messages.
 #define MQTT_ERROR
 
@@ -107,7 +107,7 @@
 // Largest full packet we're able to send.
 // Need to be able to store at least ~90 chars for a connect packet with full
 // 23 char client ID.
-#define MAXBUFFERSIZE (512)
+#define MAXBUFFERSIZE (150)
 
 #define MQTT_CONN_USERNAMEFLAG 0x80
 #define MQTT_CONN_PASSWORDFLAG 0x40

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MQTT Library
-version=2.4.4
+version=2.5.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=MQTT library that supports the FONA, ESP8266, ESP32, Yun, and generic Arduino Client hardware.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MQTT Library
-version=2.4.3
+version=2.4.4
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=MQTT library that supports the FONA, ESP8266, ESP32, Yun, and generic Arduino Client hardware.


### PR DESCRIPTION
Callback functions within subscription packets are currently not processed if `processPacketsUntil()` receives a subscription packet. While `processPacketsUntil()` does call `handleSubscriptionPacket()`, `handleSubscriptionPacket()` fills the `Adafruit_Subscription` object but does not call the callbacks as mentioned in its docstring ("// Handle any data coming in for subscriptions and fires them off to the appropriate callback") nor does it mark the subscription message as "read" (implemented in https://github.com/adafruit/Adafruit_MQTT_Library/pull/195). 

This causes any subscription packet picked up during `processPacketsUntil()`'s period (called by a `ping()` or `publish()`) to never execute its callback method. 

This pull request:
* Adds a new method, `processSubscriptionPacket` which executes a subscription packet's associated callback and marks the message as "read"
* Refactors `processPackets` and `processPacketsUntil` to use `processSubscriptionPacket`

This was tested against the Adafruit IO WipperSnapper library's synchronization function and was OK for: 5x servos re-syncing, 2x DS18x components syncing, 2x i2c devices + servo + 2x dsx + 1x pin component syncing

ping @ladyada for review