### PR TITLE
Fix connectErrorString return type for ESP-32 BSP 2.0.8

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -329,46 +329,9 @@ uint16_t Adafruit_MQTT::readFullPacket(uint8_t *buffer, uint16_t maxsize,
 
 #ifdef ARDUINO_ARCH_ESP32
 const char *Adafruit_MQTT::connectErrorString(int8_t code) {
-  const char *statusMsg;
-  switch (code) {
-  case 1:
-    statusMsg =
-        "The Server does not support the level of the MQTT protocol requested";
-    break;
-  case 2:
-    statusMsg =
-        "The Client identifier is correct UTF-8 but not allowed by the Server";
-    break;
-  case 3:
-    statusMsg = "The MQTT service is unavailable";
-    break;
-  case 4:
-    statusMsg = "The data in the user name or password is malformed";
-    break;
-  case 5:
-    statusMsg = "Not authorized to connect";
-    break;
-  case 6:
-    statusMsg = "Exceeded reconnect rate limit. Please try again later.";
-    break;
-  case 7:
-    statusMsg = "You have been banned from connecting. Please contact the MQTT "
-                "server administrator for more details.";
-    break;
-  case -1:
-    statusMsg = "Connection failed";
-    break;
-  case -2:
-    statusMsg = "Failed to subscribe";
-    break;
-  default:
-    statusMsg = "Unknown error";
-    break;
-  }
-  return statusMsg;
-}
 #else
 const __FlashStringHelper *Adafruit_MQTT::connectErrorString(int8_t code) {
+#endif
   switch (code) {
   case 1:
     return F(
@@ -395,7 +358,6 @@ const __FlashStringHelper *Adafruit_MQTT::connectErrorString(int8_t code) {
     return F("Unknown error");
   }
 }
-#endif
 
 bool Adafruit_MQTT::disconnect() {
 

--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -327,6 +327,47 @@ uint16_t Adafruit_MQTT::readFullPacket(uint8_t *buffer, uint16_t maxsize,
   return ((pbuff - buffer) + rlen);
 }
 
+#ifdef ARDUINO_ARCH_ESP32
+const char *Adafruit_MQTT::connectErrorString(int8_t code) {
+  const char *statusMsg;
+  switch (code) {
+  case 1:
+    statusMsg =
+        "The Server does not support the level of the MQTT protocol requested";
+    break;
+  case 2:
+    statusMsg =
+        "The Client identifier is correct UTF-8 but not allowed by the Server";
+    break;
+  case 3:
+    statusMsg = "The MQTT service is unavailable";
+    break;
+  case 4:
+    statusMsg = "The data in the user name or password is malformed";
+    break;
+  case 5:
+    statusMsg = "Not authorized to connect";
+    break;
+  case 6:
+    statusMsg = "Exceeded reconnect rate limit. Please try again later.";
+    break;
+  case 7:
+    statusMsg = "You have been banned from connecting. Please contact the MQTT "
+                "server administrator for more details.";
+    break;
+  case -1:
+    statusMsg = "Connection failed";
+    break;
+  case -2:
+    statusMsg = "Failed to subscribe";
+    break;
+  default:
+    statusMsg = "Unknown error";
+    break;
+  }
+  return statusMsg;
+}
+#else
 const __FlashStringHelper *Adafruit_MQTT::connectErrorString(int8_t code) {
   switch (code) {
   case 1:
@@ -354,6 +395,7 @@ const __FlashStringHelper *Adafruit_MQTT::connectErrorString(int8_t code) {
     return F("Unknown error");
   }
 }
+#endif
 
 bool Adafruit_MQTT::disconnect() {
 

--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -166,11 +166,19 @@ public:
   int8_t connect();
   int8_t connect(const char *user, const char *pass);
 
-  // Return a printable string version of the error code returned by
+#ifdef ARDUINO_ARCH_ESP32
+  // Returns a printable string version of the error code returned by
+  // connect(). Preprocessor due to breaking change within
+  // Arduino ESP32 BSP v2.0.8
+  // see: https://github.com/espressif/arduino-esp32/pull/7941
+  const char *connectErrorString(int8_t code);
+#else
+  // Returns a printable string version of the error code returned by
   // connect(). This returns a __FlashStringHelper*, which points to a
   // string stored in flash, but can be directly passed to e.g.
   // Serial.println without any further processing.
   const __FlashStringHelper *connectErrorString(int8_t code);
+#endif;
 
   // Sends MQTT disconnect packet and calls disconnectServer()
   bool disconnect();

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MQTT Library
-version=2.5.2
+version=2.5.3
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=MQTT library that supports the FONA, ESP8266, ESP32, Yun, and generic Arduino Client hardware.


### PR DESCRIPTION
This PR fixes return type of `connectErrorString` due to a change in https://github.com/espressif/arduino-esp32/pull/7941 by adding a preprocessor for ESP32-arch and returning a const char * rather than a `__FlashStringHelper` to `Serial.println()`.

Related: https://github.com/adafruit/Adafruit_Learning_System_Guides/pull/2483