### PR TITLE
Revert "Fix connectErrorString return type for ESP-32 BSP 2.0.8"

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -327,11 +327,7 @@ uint16_t Adafruit_MQTT::readFullPacket(uint8_t *buffer, uint16_t maxsize,
   return ((pbuff - buffer) + rlen);
 }
 
-#ifdef ARDUINO_ARCH_ESP32
-const char *Adafruit_MQTT::connectErrorString(int8_t code) {
-#else
 const __FlashStringHelper *Adafruit_MQTT::connectErrorString(int8_t code) {
-#endif
   switch (code) {
   case 1:
     return F(

--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -166,19 +166,11 @@ public:
   int8_t connect();
   int8_t connect(const char *user, const char *pass);
 
-#ifdef ARDUINO_ARCH_ESP32
-  // Returns a printable string version of the error code returned by
-  // connect(). Preprocessor due to breaking change within
-  // Arduino ESP32 BSP v2.0.8
-  // see: https://github.com/espressif/arduino-esp32/pull/7941
-  const char *connectErrorString(int8_t code);
-#else
-  // Returns a printable string version of the error code returned by
+  // Return a printable string version of the error code returned by
   // connect(). This returns a __FlashStringHelper*, which points to a
   // string stored in flash, but can be directly passed to e.g.
   // Serial.println without any further processing.
   const __FlashStringHelper *connectErrorString(int8_t code);
-#endif;
 
   // Sends MQTT disconnect packet and calls disconnectServer()
   bool disconnect();

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MQTT Library
-version=2.5.3
+version=2.5.2
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=MQTT library that supports the FONA, ESP8266, ESP32, Yun, and generic Arduino Client hardware.


### PR DESCRIPTION
Reverts adafruit/Adafruit_MQTT_Library#222
**Why?** "Arduino Release v2.0.9 based on ESP-IDF v4.4.4" PR https://github.com/espressif/arduino-esp32/pull/8147 is to "revert to the previous definition of FPSTR and F macros."