### PR TITLE
Update io.adafruit.com certificate fingerprint

### DIFF
--- a/examples/adafruitio_secure_esp8266/adafruitio_secure_esp8266.ino
+++ b/examples/adafruitio_secure_esp8266/adafruitio_secure_esp8266.ino
@@ -44,12 +44,12 @@ WiFiClientSecure client;
 Adafruit_MQTT_Client mqtt(&client, AIO_SERVER, AIO_SERVERPORT, AIO_USERNAME, AIO_KEY);
 
 // io.adafruit.com SHA1 fingerprint
-/* WARNING - This value was last updated on 08/15/22 and may not be up-to-date!
+/* WARNING - This value was last updated on 07/02/24 and may not be up-to-date!
 *  If security is a concern for your project, we strongly recommend users impacted by this moving
 *  to ESP32 which has certificate verification by storing root certs and having a
 *  chain-of-trust rather than doing individual certificate fingerprints.
 */
-static const char *fingerprint PROGMEM = "4E C1 52 73 24 A8 36 D6 7A 4C 67 C7 91 0C 0A 22 B9 2D 5B CA";
+static const char *fingerprint PROGMEM = "23 97 B0 6A 5A DA 2C F7 F3 3D 0E AB 9B E8 F7 3A 97 A4 07 C1";
 
 /****************************** Feeds ***************************************/
 


### PR DESCRIPTION
The SHA1 fingerprint of io.adafruit.com is expired in the example used in this repo

The new correct fingerprint is "23 97 B0 6A 5A DA 2C F7 F3 3D 0E AB 9B E8 F7 3A 97 A4 07 C1"

This PR solves #230