### PR TITLE
docs(ssl): Update TLS/SSL certificate fingerprint instructions

### DIFF
--- a/examples/adafruitio_secure_esp8266/adafruitio_secure_esp8266.ino
+++ b/examples/adafruitio_secure_esp8266/adafruitio_secure_esp8266.ino
@@ -44,10 +44,24 @@ WiFiClientSecure client;
 Adafruit_MQTT_Client mqtt(&client, AIO_SERVER, AIO_SERVERPORT, AIO_USERNAME, AIO_KEY);
 
 // io.adafruit.com SHA1 fingerprint
-/* WARNING - This value was last updated on 07/14/25 and may not be up-to-date!
-*  If security is a concern for your project, we strongly recommend users impacted by this moving
-*  to ESP32 which has certificate verification by storing root certs and having a
-*  chain-of-trust rather than doing individual certificate fingerprints.
+/* WARNING - This value was last updated on 07/14/25 and may not be up-to-date (6monthly updates)!
+*  If security is a concern for your project, we strongly recommend users impacted by this move
+*  to a larger MCU like ESP32 which has certificate verification by storing root certs and having
+*  a chain-of-trust rather than doing individual certificate fingerprints.
+*  Mac/Linux/WSL users run the following command to get the latest fingerprint (with OpenSSL):
+```
+openssl s_client -connect [io.adafruit.com]:8883 -showcerts </dev/null 2>/dev/null | openssl x509 -fingerprint -noout | sed 's/:/ /g' | sed 's/SHA1 Fingerprint=//'
+```
+*  Windows users can use powershell and not need to install OpenSSL:
+```
+$tcpClient = New-Object System.Net.Sockets.TcpClient("io.adafruit.com", 8883);
+$sslStream = New-Object System.Net.Security.SslStream($tcpClient.GetStream(), $false, ({$True}));
+$sslStream.AuthenticateAsClient("io.adafruit.com");
+$cert = $sslStream.RemoteCertificate;
+$fingerprint = ($cert.GetCertHashString());
+Write-Output ($fingerprint -replace '(.{2})', '$1 ' -replace ' $', '');
+```
+* Replace the value below with your updated SHA1 fingerprint for io.adafruit.com:
 */
 static const char *fingerprint PROGMEM = "47 D2 CB 14 DF 38 97 59 C6 65 1A 1F 3E 00 1E 53 CC A5 17 E0";
 
@@ -84,7 +98,7 @@ void setup() {
   Serial.println("WiFi connected");
   Serial.println("IP address: "); Serial.println(WiFi.localIP());
 
-  // check the fingerprint of io.adafruit.com's SSL cert
+  // check the fingerprint of io.adafruit.com's SSL cert (*see above to update)
   client.setFingerprint(fingerprint);
 }
 

--- a/examples/adafruitio_secure_esp8266/adafruitio_secure_esp8266.ino
+++ b/examples/adafruitio_secure_esp8266/adafruitio_secure_esp8266.ino
@@ -44,15 +44,16 @@ WiFiClientSecure client;
 Adafruit_MQTT_Client mqtt(&client, AIO_SERVER, AIO_SERVERPORT, AIO_USERNAME, AIO_KEY);
 
 // io.adafruit.com SHA1 fingerprint
-/* WARNING - This value was last updated on 07/14/25 and may not be up-to-date (6monthly updates)!
+/* WARNING - This value was last updated on 07/14/25 and may not be up-to-date!
 *  If security is a concern for your project, we strongly recommend users impacted by this move
 *  to a larger MCU like ESP32 which has certificate verification by storing root certs and having
-*  a chain-of-trust rather than doing individual certificate fingerprints.
-*  Mac/Linux/WSL users run the following command to get the latest fingerprint (with OpenSSL):
+*  a chain-of-trust rather than doing individual certificate fingerprints. */
+/*  For Mac, Linux and WSL users: Run the following command to get the latest fingerprint (with OpenSSL):
 ```
 openssl s_client -connect [io.adafruit.com]:8883 -showcerts </dev/null 2>/dev/null | openssl x509 -fingerprint -noout | sed 's/:/ /g' | sed 's/SHA1 Fingerprint=//'
 ```
-*  Windows users can use powershell and not need to install OpenSSL:
+*/
+/*  Windows users can use Powershell and not need to install OpenSSL:
 ```
 $tcpClient = New-Object System.Net.Sockets.TcpClient("io.adafruit.com", 8883);
 $sslStream = New-Object System.Net.Security.SslStream($tcpClient.GetStream(), $false, ({$True}));
@@ -61,8 +62,9 @@ $cert = $sslStream.RemoteCertificate;
 $fingerprint = ($cert.GetCertHashString());
 Write-Output ($fingerprint -replace '(.{2})', '$1 ' -replace ' $', '');
 ```
-* Replace the value below with your updated SHA1 fingerprint for io.adafruit.com:
 */
+
+/* Replace the value below with your updated SHA1 fingerprint for io.adafruit.com: */
 static const char *fingerprint PROGMEM = "47 D2 CB 14 DF 38 97 59 C6 65 1A 1F 3E 00 1E 53 CC A5 17 E0";
 
 /****************************** Feeds ***************************************/
@@ -98,7 +100,7 @@ void setup() {
   Serial.println("WiFi connected");
   Serial.println("IP address: "); Serial.println(WiFi.localIP());
 
-  // check the fingerprint of io.adafruit.com's SSL cert (*see above to update)
+  /* Verify SSL fingerprint (see above for instructions to update the SSL fingerprint) */
   client.setFingerprint(fingerprint);
 }
 


### PR DESCRIPTION
Certificates for IO.adafruit.com are changing to a 6month validity, and it's felt that fingerprinting should no longer be recommended, but instructions updated as a large number of esp8266 users still exist on the IO platform.

Relates to:
https://3.basecamp.com/3732686/buckets/17625714/todos/9458087406