### PR TITLE
In addition to ESP8266, ESP32 needs strncasecmp()

### DIFF
--- a/Adafruit_MQTT.cpp
+++ b/Adafruit_MQTT.cpp
@@ -32,7 +32,7 @@ static char *dtostrf(double val, signed char width, unsigned char prec,
 }
 #endif
 
-#if defined(ESP8266)
+#if defined(ESP8266) || defined(ESP32)
 int strncasecmp(const char *str1, const char *str2, int len) {
   int d = 0;
   while (len--) {


### PR DESCRIPTION
I'm using the arduino IDE 2.3.10. My board type is "DOIT ESP32 DEVKIT V1". I have esp32 3.3.10. I'm building on a M4 mac mini with Tahoe 26.5.1.

I saw this error when compiling:
```
/Users/leres/Documents/Arduino/libraries/Adafruit_MQTT_Library/Adafruit_MQTT.cpp: In member function 'Adafruit_MQTT_Subscribe* Adafruit_MQTT::handleSubscriptionPacket(uint16_t)':
/Users/leres/Documents/Arduino/libraries/Adafruit_MQTT_Library/Adafruit_MQTT.cpp:602:11: error: 'strncasecmp' was not declared in this scope; did you mean 'strncasecmp_P'?
  602 |       if (strncasecmp((char *)buffer + topicstart, subscriptions[i]->topic,
      |           ^~~~~~~~~~~
      |           strncasecmp_P
exit status 1
```
What solved this for me is to provide strncasecmp() when ESP32 is defined.